### PR TITLE
トーク画面のテキストボックス上部に区切り線を追加

### DIFF
--- a/android-client/app/src/main/res/layout/activity_talk.xml
+++ b/android-client/app/src/main/res/layout/activity_talk.xml
@@ -10,8 +10,8 @@
         android:id="@+id/talk_recycler_view"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginBottom="8dp"
-        app:layout_constraintBottom_toTopOf="@+id/input_message_box_talk"
+        android:layout_marginBottom="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/horizontal_line_talk"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -40,5 +40,13 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
+
+    <View
+        android:id="@+id/horizontal_line_talk"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginBottom="8dp"
+        android:background="@android:color/darker_gray"
+        app:layout_constraintBottom_toTopOf="@+id/input_message_box_talk" />
 
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
issue #22

![kugirisen](https://user-images.githubusercontent.com/24669535/44963601-9ff5a100-af66-11e8-9b4a-23224026c665.PNG)

# 概要
トーク画面のテキストボックスとrecyclerviewの間に区切り線を実装しました。
変更点は少ないのでさくっとレビューしていただければOKです。