### PR TITLE
新規グループ作成画面のUIを実装

### DIFF
--- a/android-client/app/build.gradle
+++ b/android-client/app/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    
+
     // Groupieのインストール
     implementation 'com.xwray:groupie:2.1.0'
     implementation 'com.xwray:groupie-kotlin-android-extensions:2.1.0'

--- a/android-client/app/src/main/AndroidManifest.xml
+++ b/android-client/app/src/main/AndroidManifest.xml
@@ -12,14 +12,16 @@
         <activity android:name=".LoginActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".RegistrationActivity"></activity>
-        <activity android:name=".HomeActivity"></activity>
+        <activity android:name=".RegistrationActivity" />
+        <activity android:name=".HomeActivity" />
         <activity
             android:name=".TalkActivity"
             android:label="@string/title_activity_talk" />
+        <activity android:name=".CreateGroupActivity"></activity>
     </application>
 
 </manifest>

--- a/android-client/app/src/main/AndroidManifest.xml
+++ b/android-client/app/src/main/AndroidManifest.xml
@@ -21,7 +21,11 @@
         <activity
             android:name=".TalkActivity"
             android:label="@string/title_activity_talk" />
-        <activity android:name=".CreateGroupActivity"></activity>
+        <activity android:name=".CreateGroupActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".HomeActivity"/>
+        </activity>
     </application>
 
 </manifest>

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -15,6 +15,7 @@ class CreateGroupActivity : AppCompatActivity() {
     val groupAdapter = GroupAdapter<ViewHolder>().apply {
         spanCount = 4
     }
+    lateinit var dummyUserItems: MutableList<SelectableUserItem>
     val selectedUsers = mutableListOf<SelectableUserItem>()     // 選択されたユーザのリスト
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -22,6 +23,8 @@ class CreateGroupActivity : AppCompatActivity() {
         setContentView(R.layout.activity_create_group)
 
         supportActionBar?.title = "新しいグループを作る"
+
+        generateDummyUsersItems()
 
         recycler_view_create_group.apply {
             layoutManager = GridLayoutManager(this@CreateGroupActivity, groupAdapter.spanCount).apply {
@@ -73,7 +76,7 @@ class CreateGroupActivity : AppCompatActivity() {
     // ユーザが決める一意なIDではなく、表示している名前の部分一致で検索する
     private fun fetchSearchedUsers(keyword: String): List<SelectableUserItem> {
         // TODO: ダミーデータじゃなくて、ローカルDBを検索して同様のことをする
-        val searchedUsers = generateDummyUsersItems().filter { item -> item.userName.indexOf(keyword) >= 0 }
+        val searchedUsers = dummyUserItems.filter { item -> item.userName.indexOf(keyword) >= 0 }
         return searchedUsers
     }
 
@@ -88,8 +91,8 @@ class CreateGroupActivity : AppCompatActivity() {
         updateGuideTextview()
     }
 
-    private fun generateDummyUsersItems(): List<SelectableUserItem> {
-        val dummyUserItems = mutableListOf<SelectableUserItem>(
+    private fun generateDummyUsersItems() {
+        dummyUserItems = mutableListOf<SelectableUserItem>(
                 SelectableUserItem("a", "saito yuya", 0),
                 SelectableUserItem("b", "suzuki yuto", 0),
                 SelectableUserItem("c", "suzuki takuma", 0),
@@ -99,7 +102,6 @@ class CreateGroupActivity : AppCompatActivity() {
         )
         for (i in 1..20)
             dummyUserItems.add(SelectableUserItem("b", "suzuki yuto", 0))
-        return dummyUserItems
     }
 
     inner class SelectableUserItem(val userId: String,      // Userに登録させる一意なID

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -4,14 +4,18 @@ import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.GridLayoutManager
 import android.util.Log
+import android.widget.Toast
 import com.xwray.groupie.GroupAdapter
+import com.xwray.groupie.kotlinandroidextensions.Item
 import com.xwray.groupie.kotlinandroidextensions.ViewHolder
 import kotlinx.android.synthetic.main.activity_create_group.*
+import kotlinx.android.synthetic.main.item_friend_friends.*
 
 class CreateGroupActivity : AppCompatActivity() {
     val groupAdapter = GroupAdapter<ViewHolder>().apply {
         spanCount = 4
     }
+    val selectedUsers = mutableListOf<SelectableUserItem>()     // 選択されたユーザのリスト
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -32,6 +36,7 @@ class CreateGroupActivity : AppCompatActivity() {
             Log.d("CreateGroupActivity", "文字列${keyword}が名前に含まれるユーザを検索")
 
             // TODO: ローカルDBからkeywordを名前に含むユーザを引っ張ってきてリストを作成する
+            displaySearchedUser(keyword)
         }
 
         fab_create_group.setOnClickListener {
@@ -41,6 +46,66 @@ class CreateGroupActivity : AppCompatActivity() {
 
         delete_button_create_group.setOnClickListener {
             search_box_create_group.text.clear()
+        }
+    }
+
+    private fun updateGuideTextview() {
+        val numberSelected = selectedUsers.size
+        if (numberSelected > 0) {
+            guide_textview_create_group.text = "グループに追加したい人を選んでください(${numberSelected}人選択中)"
+        } else {
+            guide_textview_create_group.text = "グループに追加したい人を選んでください"
+        }
+    }
+
+    // グループ追加で検索するときは、自分の友達一覧から検索する
+    // ユーザが決める一意なIDではなく、表示している名前の部分一致で検索する
+    private fun fetchSearchedUsers(keyword: String): List<SelectableUserItem> {
+        // TODO: ダミーデータじゃなくて、ローカルDBを検索して同様のことをする
+        val searchedUsers = generateDummyUsersItems().filter { item -> item.userName.indexOf(keyword) >= 0 }
+        return searchedUsers
+    }
+
+    private fun displaySearchedUser(keyword: String) {
+        val items = fetchSearchedUsers(keyword)
+        if (items.isEmpty()) {
+            Toast.makeText(this, "一致するユーザが見つかりません", Toast.LENGTH_LONG).show()
+            return
+        }
+        groupAdapter.clear()
+        groupAdapter.addAll(items)
+        updateGuideTextview()
+    }
+
+    private fun generateDummyUsersItems(): List<SelectableUserItem> {
+        val dummyUserItems = listOf<SelectableUserItem>(
+                SelectableUserItem("a", "saito yuya", 0),
+                SelectableUserItem("b", "suzuki yuto", 0),
+                SelectableUserItem("c", "suzuki takuma", 0),
+                SelectableUserItem("d", "honda keisuke", 0),
+                SelectableUserItem("e", "kawasaki tomoya", 0),
+                SelectableUserItem("f", "yamaha tarou", 0)
+        )
+        return dummyUserItems
+    }
+
+    inner class SelectableUserItem(val userId: String,      // Userに登録させる一意なID
+                                   val userName: String,    // Userが表示したい名前
+                                   val userIconId: Int,
+                                   var isSelected: Boolean = false) : Item() {
+        override fun bind(viewHolder: com.xwray.groupie.kotlinandroidextensions.ViewHolder, position: Int) {
+            viewHolder.user_name_textview_friends.text = userName
+            viewHolder.itemView.alpha = if (isSelected) 1f else 0.6f
+            // TODO : 友達のアイコンを表示する
+        }
+
+        override fun getLayout(): Int = R.layout.item_friend_friends
+
+        override fun getSpanSize(spanCount: Int, position: Int): Int = spanCount / 4
+
+        // デバッグ用
+        override fun toString(): String {
+            return userName
         }
     }
 }

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -1,0 +1,12 @@
+package com.sample.android_client
+
+import android.support.v7.app.AppCompatActivity
+import android.os.Bundle
+
+class CreateGroupActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_create_group)
+    }
+}

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -46,12 +46,6 @@ class CreateGroupActivity : AppCompatActivity() {
             adapter = hGroupAdapter
         }
 
-        search_button_create_group.setOnClickListener {
-            val keyword = search_box_create_group.text.toString()
-            Log.d("CreateGroupActivity", "文字列${keyword}が名前に含まれるユーザを検索")
-            displaySearchedUser(keyword)
-        }
-
         search_box_create_group.addTextChangedListener(object: TextWatcher {
             override fun afterTextChanged(p0: Editable?) {
                 displaySearchedUser(p0.toString())

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -123,10 +123,6 @@ class CreateGroupActivity : AppCompatActivity() {
 
     private fun displaySearchedUser(keyword: String) {
         val items = fetchSearchedUsers(keyword)
-        if (items.isEmpty()) {
-            Toast.makeText(this, "一致するユーザが見つかりません", Toast.LENGTH_LONG).show()
-            return
-        }
         groupAdapter.clear()
         groupAdapter.addAll(items)
         updateGuideTextview()

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -36,19 +36,6 @@ class CreateGroupActivity : AppCompatActivity() {
             itemAnimator = null
         }
 
-        hGroupAdapter.add(ScrollUserItem("a", "hoge", 0))
-        hGroupAdapter.add(ScrollUserItem("a", "fuga", 0))
-        hGroupAdapter.add(ScrollUserItem("a", "pote", 0))
-        hGroupAdapter.add(ScrollUserItem("a", "hoge", 0))
-        hGroupAdapter.add(ScrollUserItem("a", "fuga", 0))
-        hGroupAdapter.add(ScrollUserItem("a", "pote", 0))
-        hGroupAdapter.add(ScrollUserItem("a", "hoge", 0))
-        hGroupAdapter.add(ScrollUserItem("a", "fuga", 0))
-        hGroupAdapter.add(ScrollUserItem("a", "pote", 0))
-        hGroupAdapter.add(ScrollUserItem("a", "hoge", 0))
-        hGroupAdapter.add(ScrollUserItem("a", "fuga", 0))
-        hGroupAdapter.add(ScrollUserItem("a", "pote", 0))
-
 
         horizontal_recycler_view_create_group.apply {
             layoutManager = LinearLayoutManager(this@CreateGroupActivity, LinearLayoutManager.HORIZONTAL, false)
@@ -81,6 +68,14 @@ class CreateGroupActivity : AppCompatActivity() {
             }
             sItem.notifyChanged()
             updateGuideTextview()
+            updateScrollView()
+        }
+    }
+
+    private fun updateScrollView() {
+        hGroupAdapter.clear()
+        for (user in selectedUsers) {
+            hGroupAdapter.add(ScrollUserItem(user.userId, user.userName, user.userIconId))
         }
     }
 
@@ -149,7 +144,9 @@ class CreateGroupActivity : AppCompatActivity() {
                                val userName: String,
                                val userIconId: Int) : Item() {
         override fun bind(viewHolder: ViewHolder, position: Int) {
-            viewHolder.user_name_textview_scroll.text = userName
+            val limitLength = 10
+            val displayName = if (userName.length <= limitLength) userName else userName.substring(0 until limitLength - 1) + "..."
+            viewHolder.user_name_textview_scroll.text = displayName
         }
 
         override fun getLayout(): Int = R.layout.item_user_scroll

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -31,6 +31,9 @@ class CreateGroupActivity : AppCompatActivity() {
         // ダミーデータの作成
         generateDummyUsersItems()
 
+        // 最初は全ての友達を表示する
+        displaySearchedUser()
+
         // 検索したユーザを表示するためのrecyclerviewの設定
         recycler_view_create_group.apply {
             layoutManager = GridLayoutManager(this@CreateGroupActivity, groupAdapter.spanCount).apply {
@@ -121,7 +124,7 @@ class CreateGroupActivity : AppCompatActivity() {
         return searchedUsers
     }
 
-    private fun displaySearchedUser(keyword: String) {
+    private fun displaySearchedUser(keyword: String = "") {
         val items = fetchSearchedUsers(keyword)
         groupAdapter.clear()
         groupAdapter.addAll(items)

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -49,8 +49,23 @@ class CreateGroupActivity : AppCompatActivity() {
         }
 
         fab_create_group.setOnClickListener {
-            // TODO: 新しくグループを作ってサーバのDBに登録する処理
+            val groupName = group_name_edittext_create_group.text.toString()
+
+            if (groupName.isEmpty()) {
+                Toast.makeText(this, "グループ名を入力してください", Toast.LENGTH_LONG).show()
+                return@setOnClickListener
+            }
+
+            if (selectedUsers.isEmpty()) {
+                Toast.makeText(this, "選択されたユーザが存在しません", Toast.LENGTH_LONG).show()
+                return@setOnClickListener
+            }
+
+            // TODO: 選択されたユーザのリストで新しくグループを作ってサーバのDBに登録する処理
             // TODO: ローカルDBに登録する処理
+
+            Toast.makeText(this, "グループを作成しました！", Toast.LENGTH_LONG).show()
+            finish()
         }
 
         delete_button_create_group.setOnClickListener {

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -47,6 +47,19 @@ class CreateGroupActivity : AppCompatActivity() {
         delete_button_create_group.setOnClickListener {
             search_box_create_group.text.clear()
         }
+
+        groupAdapter.setOnItemClickListener { item, view ->
+            val sItem = item as SelectableUserItem
+            if (sItem.isSelected) {
+                selectedUsers.remove(sItem)
+                sItem.isSelected = false
+            } else {
+                selectedUsers.add(sItem)
+                sItem.isSelected = true
+            }
+            sItem.notifyChanged()
+            updateGuideTextview()
+        }
     }
 
     private fun updateGuideTextview() {

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -89,7 +89,7 @@ class CreateGroupActivity : AppCompatActivity() {
     }
 
     private fun generateDummyUsersItems(): List<SelectableUserItem> {
-        val dummyUserItems = listOf<SelectableUserItem>(
+        val dummyUserItems = mutableListOf<SelectableUserItem>(
                 SelectableUserItem("a", "saito yuya", 0),
                 SelectableUserItem("b", "suzuki yuto", 0),
                 SelectableUserItem("c", "suzuki takuma", 0),
@@ -97,6 +97,8 @@ class CreateGroupActivity : AppCompatActivity() {
                 SelectableUserItem("e", "kawasaki tomoya", 0),
                 SelectableUserItem("f", "yamaha tarou", 0)
         )
+        for (i in 1..20)
+            dummyUserItems.add(SelectableUserItem("b", "suzuki yuto", 0))
         return dummyUserItems
     }
 

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -26,8 +26,10 @@ class CreateGroupActivity : AppCompatActivity() {
 
         supportActionBar?.title = "新しいグループを作る"
 
+        // ダミーデータの作成
         generateDummyUsersItems()
 
+        // 検索したユーザを表示するためのrecyclerviewの設定
         recycler_view_create_group.apply {
             layoutManager = GridLayoutManager(this@CreateGroupActivity, groupAdapter.spanCount).apply {
                 spanSizeLookup = groupAdapter.spanSizeLookup
@@ -36,7 +38,7 @@ class CreateGroupActivity : AppCompatActivity() {
             itemAnimator = null
         }
 
-
+        // 選択したユーザを画面下部に横スクロールで表示するためのrecyclerviewの設定
         horizontal_recycler_view_create_group.apply {
             layoutManager = LinearLayoutManager(this@CreateGroupActivity, LinearLayoutManager.HORIZONTAL, false)
             adapter = hGroupAdapter
@@ -162,6 +164,7 @@ class CreateGroupActivity : AppCompatActivity() {
             val limitLength = 10
             val displayName = if (userName.length <= limitLength) userName else userName.substring(0 until limitLength - 1) + "..."
             viewHolder.user_name_textview_scroll.text = displayName
+            // TODO : 友達のアイコンを表示する
         }
 
         override fun getLayout(): Int = R.layout.item_user_scroll

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -29,7 +29,9 @@ class CreateGroupActivity : AppCompatActivity() {
 
         search_button_create_group.setOnClickListener {
             val keyword = search_box_create_group.text.toString()
-            Log.d("CreateGroupActivity", "文字列${keyword}が含まれるユーザを検索")
+            Log.d("CreateGroupActivity", "文字列${keyword}が名前に含まれるユーザを検索")
+
+            // TODO: ローカルDBからkeywordを名前に含むユーザを引っ張ってきてリストを作成する
         }
 
         fab_create_group.setOnClickListener {

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -3,6 +3,7 @@ package com.sample.android_client
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.GridLayoutManager
+import android.support.v7.widget.LinearLayoutManager
 import android.util.Log
 import android.widget.Toast
 import com.xwray.groupie.GroupAdapter
@@ -15,6 +16,7 @@ class CreateGroupActivity : AppCompatActivity() {
     val groupAdapter = GroupAdapter<ViewHolder>().apply {
         spanCount = 4
     }
+    val hGroupAdapter = GroupAdapter<ViewHolder>()
     lateinit var dummyUserItems: MutableList<SelectableUserItem>
     val selectedUsers = mutableListOf<SelectableUserItem>()     // 選択されたユーザのリスト
 
@@ -32,6 +34,25 @@ class CreateGroupActivity : AppCompatActivity() {
             }
             adapter = groupAdapter
             itemAnimator = null
+        }
+
+        hGroupAdapter.add(ScrollUserItem("a", "hoge", 0))
+        hGroupAdapter.add(ScrollUserItem("a", "fuga", 0))
+        hGroupAdapter.add(ScrollUserItem("a", "pote", 0))
+        hGroupAdapter.add(ScrollUserItem("a", "hoge", 0))
+        hGroupAdapter.add(ScrollUserItem("a", "fuga", 0))
+        hGroupAdapter.add(ScrollUserItem("a", "pote", 0))
+        hGroupAdapter.add(ScrollUserItem("a", "hoge", 0))
+        hGroupAdapter.add(ScrollUserItem("a", "fuga", 0))
+        hGroupAdapter.add(ScrollUserItem("a", "pote", 0))
+        hGroupAdapter.add(ScrollUserItem("a", "hoge", 0))
+        hGroupAdapter.add(ScrollUserItem("a", "fuga", 0))
+        hGroupAdapter.add(ScrollUserItem("a", "pote", 0))
+
+
+        horizontal_recycler_view_create_group.apply {
+            layoutManager = LinearLayoutManager(this@CreateGroupActivity, LinearLayoutManager.HORIZONTAL, false)
+            adapter = hGroupAdapter
         }
 
         search_button_create_group.setOnClickListener {
@@ -109,7 +130,7 @@ class CreateGroupActivity : AppCompatActivity() {
                                    val userIconId: Int,
                                    var isSelected: Boolean = false) : Item() {
         override fun bind(viewHolder: com.xwray.groupie.kotlinandroidextensions.ViewHolder, position: Int) {
-            viewHolder.user_name_textview_friends.text = userName
+            viewHolder.user_name_textview_scroll.text = userName
             viewHolder.itemView.alpha = if (isSelected) 1f else 0.6f
             // TODO : 友達のアイコンを表示する
         }
@@ -122,5 +143,15 @@ class CreateGroupActivity : AppCompatActivity() {
         override fun toString(): String {
             return userName
         }
+    }
+
+    inner class ScrollUserItem(val userId: String,
+                               val userName: String,
+                               val userIconId: Int) : Item() {
+        override fun bind(viewHolder: ViewHolder, position: Int) {
+            viewHolder.user_name_textview_scroll.text = userName
+        }
+
+        override fun getLayout(): Int = R.layout.item_user_scroll
     }
 }

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.GridLayoutManager
 import android.support.v7.widget.LinearLayoutManager
+import android.text.Editable
+import android.text.TextWatcher
 import android.util.Log
 import android.widget.Toast
 import com.xwray.groupie.GroupAdapter
@@ -49,6 +51,18 @@ class CreateGroupActivity : AppCompatActivity() {
             Log.d("CreateGroupActivity", "文字列${keyword}が名前に含まれるユーザを検索")
             displaySearchedUser(keyword)
         }
+
+        search_box_create_group.addTextChangedListener(object: TextWatcher {
+            override fun afterTextChanged(p0: Editable?) {
+                displaySearchedUser(p0.toString())
+            }
+
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+            }
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+            }
+        })
 
         fab_create_group.setOnClickListener {
             val groupName = group_name_edittext_create_group.text.toString()

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -34,8 +34,6 @@ class CreateGroupActivity : AppCompatActivity() {
         search_button_create_group.setOnClickListener {
             val keyword = search_box_create_group.text.toString()
             Log.d("CreateGroupActivity", "文字列${keyword}が名前に含まれるユーザを検索")
-
-            // TODO: ローカルDBからkeywordを名前に含むユーザを引っ張ってきてリストを作成する
             displaySearchedUser(keyword)
         }
 

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -82,9 +82,9 @@ class CreateGroupActivity : AppCompatActivity() {
     private fun updateGuideTextview() {
         val numberSelected = selectedUsers.size
         if (numberSelected > 0) {
-            guide_textview_create_group.text = "グループに追加したい人を選んでください(${numberSelected}人選択中)"
+            select_user_guide_create_group.text = "選択中のユーザ(${numberSelected})"
         } else {
-            guide_textview_create_group.text = "グループに追加したい人を選んでください"
+            select_user_guide_create_group.text = "選択中のユーザ"
         }
     }
 

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -1,12 +1,44 @@
 package com.sample.android_client
 
-import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.support.v7.widget.GridLayoutManager
+import android.util.Log
+import com.xwray.groupie.GroupAdapter
+import com.xwray.groupie.kotlinandroidextensions.ViewHolder
+import kotlinx.android.synthetic.main.activity_create_group.*
 
 class CreateGroupActivity : AppCompatActivity() {
+    val groupAdapter = GroupAdapter<ViewHolder>().apply {
+        spanCount = 4
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_create_group)
+
+        supportActionBar?.title = "新しいグループを作る"
+
+        recycler_view_create_group.apply {
+            layoutManager = GridLayoutManager(this@CreateGroupActivity, groupAdapter.spanCount).apply {
+                spanSizeLookup = groupAdapter.spanSizeLookup
+            }
+            adapter = groupAdapter
+            itemAnimator = null
+        }
+
+        search_button_create_group.setOnClickListener {
+            val keyword = search_box_create_group.text.toString()
+            Log.d("CreateGroupActivity", "文字列${keyword}が含まれるユーザを検索")
+        }
+
+        fab_create_group.setOnClickListener {
+            // TODO: 新しくグループを作ってサーバのDBに登録する処理
+            // TODO: ローカルDBに登録する処理
+        }
+
+        delete_button_create_group.setOnClickListener {
+            search_box_create_group.text.clear()
+        }
     }
 }

--- a/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
@@ -1,5 +1,6 @@
 package com.sample.android_client
 
+import android.content.Intent
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v7.widget.GridLayoutManager
@@ -43,7 +44,10 @@ class FriendsFragment : Fragment() {
             // 文字を入力するたびリアルタイムで検索していくとかもかっこいいけど難しそう
         }
 
-
+        create_group_button_friends.setOnClickListener {
+            val intent = Intent(activity, CreateGroupActivity::class.java)
+            startActivity(intent)
+        }
     }
 
     private fun displayGroupsAndFriends() {

--- a/android-client/app/src/main/java/com/sample/android_client/RoomItem.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/RoomItem.kt
@@ -9,7 +9,7 @@ data class RoomItem(val roomId: Long,
                     val roomName: String,
                     val roomIconURI: String) : Item() {
     override fun bind(viewHolder: ViewHolder, position: Int) {
-        viewHolder.user_name_textview_friends.text = roomName
+        viewHolder.user_name_textview_scroll.text = roomName
         // TODO : 相手のアイコンまたはグループアイコンを表示する
     }
 

--- a/android-client/app/src/main/res/drawable/ic_check_black_24dp.xml
+++ b/android-client/app/src/main/res/drawable/ic_check_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+</vector>

--- a/android-client/app/src/main/res/layout/activity_create_group.xml
+++ b/android-client/app/src/main/res/layout/activity_create_group.xml
@@ -13,10 +13,10 @@
         android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
-        android:paddingHorizontal="8dp"
         android:ems="10"
         android:hint="グループ名"
         android:inputType="text"
+        android:paddingHorizontal="8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -78,8 +78,9 @@
         android:id="@+id/recycler_view_create_group"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:layout_marginBottom="8dp"
         android:layout_marginTop="8dp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/horizontal_recycler_view_create_group"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/guide_textview_create_group" />
@@ -90,12 +91,23 @@
         android:layout_height="wrap_content"
         android:layout_gravity="end|bottom"
         android:layout_margin="16dp"
-        android:layout_marginBottom="16dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
         android:backgroundTint="@android:color/holo_green_light"
         android:src="@drawable/ic_check_black_24dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/horizontal_recycler_view_create_group"
+        app:layoutManager="android.support.v7.widget.LinearLayoutManager"
+        android:layout_width="0dp"
+        android:layout_height="100dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
 
 </android.support.constraint.ConstraintLayout>

--- a/android-client/app/src/main/res/layout/activity_create_group.xml
+++ b/android-client/app/src/main/res/layout/activity_create_group.xml
@@ -6,6 +6,21 @@
     android:layout_height="match_parent"
     tools:context=".CreateGroupActivity">
 
+    <EditText
+        android:id="@+id/group_name_edittext_create_group"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:paddingHorizontal="8dp"
+        android:ems="10"
+        android:hint="グループ名"
+        android:inputType="text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <ImageButton
         android:id="@+id/delete_button_create_group"
         android:layout_width="20dp"
@@ -26,7 +41,7 @@
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:ems="10"
-        android:hint="友だちのIDを検索"
+        android:hint="友達の名前を検索"
         android:inputType="textPersonName"
         android:paddingHorizontal="8dp"
         app:layout_constraintEnd_toStartOf="@+id/search_button_create_group"
@@ -52,7 +67,7 @@
         android:background="@android:color/holo_green_dark"
         android:paddingHorizontal="8dp"
         android:paddingVertical="4dp"
-        android:text="友だちになりたい人を選択してください"
+        android:text="グループに追加したい人を選択してください"
         android:textColor="@android:color/white"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
@@ -81,20 +96,6 @@
         android:src="@drawable/ic_check_black_24dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
-
-    <EditText
-        android:id="@+id/group_name_edittext_create_group"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:ems="10"
-        android:hint="グループ名"
-        android:inputType="text"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 
 
 </android.support.constraint.ConstraintLayout>

--- a/android-client/app/src/main/res/layout/activity_create_group.xml
+++ b/android-client/app/src/main/res/layout/activity_create_group.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".CreateGroupActivity">
+
+</android.support.constraint.ConstraintLayout>

--- a/android-client/app/src/main/res/layout/activity_create_group.xml
+++ b/android-client/app/src/main/res/layout/activity_create_group.xml
@@ -6,15 +6,17 @@
     android:layout_height="match_parent"
     tools:context=".CreateGroupActivity">
 
-    <Button
-        android:id="@+id/search_button_create_group"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:text="検索"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:layout_editor_absoluteY="8dp" />
+    <ImageButton
+        android:id="@+id/delete_button_create_group"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="@+id/search_box_create_group"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/search_box_create_group"
+        app:srcCompat="@android:drawable/ic_delete" />
 
     <EditText
         android:id="@+id/search_box_create_group"
@@ -22,14 +24,40 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
         android:ems="10"
         android:hint="友だちのIDを検索"
         android:inputType="textPersonName"
         android:paddingHorizontal="8dp"
         app:layout_constraintEnd_toStartOf="@+id/search_button_create_group"
+        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toEndOf="@+id/delete_button_create_group"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:layout_editor_absoluteY="8dp" />
+        app:layout_constraintTop_toBottomOf="@+id/group_name_edittext_create_group" />
+
+    <Button
+        android:id="@+id/search_button_create_group"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:text="検索"
+        app:layout_constraintBottom_toBottomOf="@+id/search_box_create_group"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/search_box_create_group" />
+
+    <TextView
+        android:id="@+id/guide_textview_create_group"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@android:color/holo_green_dark"
+        android:paddingHorizontal="8dp"
+        android:paddingVertical="4dp"
+        android:text="友だちになりたい人を選択してください"
+        android:textColor="@android:color/white"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/search_box_create_group" />
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/recycler_view_create_group"
@@ -53,29 +81,20 @@
         android:src="@drawable/ic_check_black_24dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
-    <TextView
-        android:id="@+id/guide_textview_create_group"
+
+    <EditText
+        android:id="@+id/group_name_edittext_create_group"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:background="@android:color/holo_green_dark"
-        android:text="友だちになりたい人を選択してください"
-        android:textColor="@android:color/white"
-        android:paddingHorizontal="8dp"
-        android:paddingVertical="4dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/search_box_create_group" />
-    <ImageButton
-        android:id="@+id/delete_button_create_group"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
-        app:layout_constraintBottom_toBottomOf="@+id/search_box_create_group"
+        android:ems="10"
+        android:hint="グループ名"
+        android:inputType="text"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/search_box_create_group"
-        app:srcCompat="@android:drawable/ic_delete" />
+        app:layout_constraintTop_toTopOf="parent" />
+
 
 </android.support.constraint.ConstraintLayout>

--- a/android-client/app/src/main/res/layout/activity_create_group.xml
+++ b/android-client/app/src/main/res/layout/activity_create_group.xml
@@ -78,7 +78,7 @@
         android:id="@+id/recycler_view_create_group"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/select_user_guid_create_group"
+        app:layout_constraintBottom_toTopOf="@+id/select_user_guide_create_group"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/guide_textview_create_group" />
@@ -97,7 +97,7 @@
         app:layout_constraintEnd_toEndOf="parent" />
 
     <TextView
-        android:id="@+id/select_user_guid_create_group"
+        android:id="@+id/select_user_guide_create_group"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:background="@android:color/holo_green_dark"

--- a/android-client/app/src/main/res/layout/activity_create_group.xml
+++ b/android-client/app/src/main/res/layout/activity_create_group.xml
@@ -6,4 +6,76 @@
     android:layout_height="match_parent"
     tools:context=".CreateGroupActivity">
 
+    <Button
+        android:id="@+id/search_button_create_group"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:text="検索"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:layout_editor_absoluteY="8dp" />
+
+    <EditText
+        android:id="@+id/search_box_create_group"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:ems="10"
+        android:hint="友だちのIDを検索"
+        android:inputType="textPersonName"
+        android:paddingHorizontal="8dp"
+        app:layout_constraintEnd_toStartOf="@+id/search_button_create_group"
+        app:layout_constraintStart_toEndOf="@+id/delete_button_create_group"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:layout_editor_absoluteY="8dp" />
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/recycler_view_create_group"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/guide_textview_create_group" />
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/fab_create_group"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|bottom"
+        android:layout_margin="16dp"
+        android:layout_marginBottom="16dp"
+        android:layout_marginEnd="16dp"
+        android:backgroundTint="@android:color/holo_green_light"
+        android:src="@drawable/ic_check_black_24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+    <TextView
+        android:id="@+id/guide_textview_create_group"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@android:color/holo_green_dark"
+        android:text="友だちになりたい人を選択してください"
+        android:textColor="@android:color/white"
+        android:paddingHorizontal="8dp"
+        android:paddingVertical="4dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/search_box_create_group" />
+    <ImageButton
+        android:id="@+id/delete_button_create_group"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="@+id/search_box_create_group"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/search_box_create_group"
+        app:srcCompat="@android:drawable/ic_delete" />
+
 </android.support.constraint.ConstraintLayout>

--- a/android-client/app/src/main/res/layout/activity_create_group.xml
+++ b/android-client/app/src/main/res/layout/activity_create_group.xml
@@ -44,20 +44,9 @@
         android:hint="友達の名前を検索"
         android:inputType="textPersonName"
         android:paddingHorizontal="8dp"
-        app:layout_constraintEnd_toStartOf="@+id/search_button_create_group"
-        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/delete_button_create_group"
         app:layout_constraintTop_toBottomOf="@+id/group_name_edittext_create_group" />
-
-    <Button
-        android:id="@+id/search_button_create_group"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:text="検索"
-        app:layout_constraintBottom_toBottomOf="@+id/search_box_create_group"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/search_box_create_group" />
 
     <TextView
         android:id="@+id/guide_textview_create_group"

--- a/android-client/app/src/main/res/layout/activity_create_group.xml
+++ b/android-client/app/src/main/res/layout/activity_create_group.xml
@@ -113,7 +113,7 @@
     <android.support.v7.widget.RecyclerView
         android:id="@+id/horizontal_recycler_view_create_group"
         android:layout_width="0dp"
-        android:layout_height="90dp"
+        android:layout_height="80dp"
         app:layoutManager="android.support.v7.widget.LinearLayoutManager"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/android-client/app/src/main/res/layout/activity_create_group.xml
+++ b/android-client/app/src/main/res/layout/activity_create_group.xml
@@ -78,9 +78,7 @@
         android:id="@+id/recycler_view_create_group"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginBottom="8dp"
-        android:layout_marginTop="8dp"
-        app:layout_constraintBottom_toTopOf="@+id/horizontal_recycler_view_create_group"
+        app:layout_constraintBottom_toTopOf="@+id/select_user_guid_create_group"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/guide_textview_create_group" />
@@ -98,13 +96,25 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <TextView
+        android:id="@+id/select_user_guid_create_group"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@android:color/holo_green_dark"
+        android:paddingHorizontal="8dp"
+        android:paddingVertical="4dp"
+        android:text="選択中のユーザ"
+        android:textColor="@android:color/white"
+        app:layout_constraintBottom_toTopOf="@+id/horizontal_recycler_view_create_group"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent" />
+
     <android.support.v7.widget.RecyclerView
         android:id="@+id/horizontal_recycler_view_create_group"
-        app:layoutManager="android.support.v7.widget.LinearLayoutManager"
         android:layout_width="0dp"
-        android:layout_height="100dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
+        android:layout_height="90dp"
+        app:layoutManager="android.support.v7.widget.LinearLayoutManager"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/android-client/app/src/main/res/layout/item_user_scroll.xml
+++ b/android-client/app/src/main/res/layout/item_user_scroll.xml
@@ -3,13 +3,13 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="90dp"
+    android:layout_width="70dp"
     android:layout_height="match_parent">
 
     <ImageView
         android:id="@+id/user_icon_imageview_scroll"
-        android:layout_width="50dp"
-        android:layout_height="50dp"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
         android:layout_marginBottom="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
@@ -26,6 +26,7 @@
         android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
         android:text="user_name"
+        android:textSize="12sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@+id/user_icon_imageview_scroll"
         app:layout_constraintStart_toStartOf="@+id/user_icon_imageview_scroll" />

--- a/android-client/app/src/main/res/layout/item_user_scroll.xml
+++ b/android-client/app/src/main/res/layout/item_user_scroll.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="wrap_content"
+    android:layout_width="90dp"
     android:layout_height="match_parent">
 
     <ImageView

--- a/android-client/app/src/main/res/layout/item_user_scroll.xml
+++ b/android-client/app/src/main/res/layout/item_user_scroll.xml
@@ -3,19 +3,19 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent">
 
     <ImageView
         android:id="@+id/user_icon_imageview_scroll"
         android:layout_width="50dp"
         android:layout_height="50dp"
+        android:layout_marginBottom="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toTopOf="@+id/user_name_textview_scroll"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@android:drawable/btn_star_big_on" />
 
     <TextView
@@ -25,10 +25,8 @@
         android:layout_marginBottom="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
         android:text="user_name"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@+id/user_icon_imageview_scroll"
-        app:layout_constraintStart_toStartOf="@+id/user_icon_imageview_scroll"
-        app:layout_constraintTop_toBottomOf="@+id/user_icon_imageview_scroll" />
+        app:layout_constraintStart_toStartOf="@+id/user_icon_imageview_scroll" />
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
# 概要
新規グループ作成画面のUIを実装しました。
だいたいは友達追加画面のUIを流用しているのですが、
画面下部に現在選択中のユーザを横スクロールで表示する機能を新たに加えました。
余裕のある方レビューお願いします。

# 使い方
- HomeActivityから「グループを作成」ボタンを押すと新規グループ作成画面に飛びます
- 検索ボックスにキーワードを入れて検索ボタンを押すと、そのキーワードを名前に含むユーザ一覧が表示されます
- 左のバツ印を押すと検索ワードが消去されます
- 半透明のユーザが非選択、そうでないユーザが選択状態です
- 何人かのユーザを選択した状態でグループ名が空文字列でないとき、右下のボタンを押すと新規グループ作成が完了します
- 下に現在選択しているユーザが横スクロールで表示されます

# お願いしたい実装
- 文字列を与えると、ローカルDBからその文字列を含むユーザのリストを作る処理
- 現在選択中のユーザとグループ名から、グループ情報をサーバDB・ローカルDBに保存する処理

# 認識している課題
- 現在選択しているユーザを下に表示はできるが、それをタップして解除する、みたいなことは出来ない。時間に余裕があればやりたい。
- 代わりに現在選択しているユーザを全て選択解除するボタン、くらいはすぐ作れるので作ったほうがいいかもしれない？要らないかな？
- LINEみたいに選択しているユーザがいないときは、下のスクロールビューとかガイドを非表示にしたいけど難しそう？余裕があれば。

![creategroup](https://user-images.githubusercontent.com/24669535/45203138-1b808680-b2b6-11e8-9bd8-b7c6473bc493.PNG)
