### PR TITLE
ユーザ登録画面の細かな修正

### DIFF
--- a/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
@@ -56,12 +56,39 @@ class RegistrationActivity : AppCompatActivity() {
     }
 
     private fun performRegister() {
-        val limitUserNameLength = 20        // ユーザが登録できる名前の長さの限界
-
         val userId = userid_edittext_register.text.toString()
         val name = username_edittext_register.text.toString()
         val email = email_edittext_register.text.toString()
         val password = password_edittext_register.text.toString()
+
+        verifyInputData(userId, name, email, password)
+
+        // FirebaseAuthを用いたアカウント作成
+        FirebaseAuth.getInstance().createUserWithEmailAndPassword(email, password)
+                .addOnCompleteListener {
+                    if (!it.isSuccessful) return@addOnCompleteListener
+
+                    // ユーザ登録に成功した場合
+                    Log.d("RegisterActivity", "Successfully created user with uid: ${it.result.user.uid}")
+                    userUID = it.result.user.uid
+
+                    // 登録したユーザアイコンをFirebaseのストレージに保存する
+                    // 実際はFirebaseではなく、しかるべき場所(EC2?)に保存するなどする
+                    uploadImageToFirebaseStorage()
+
+                    Toast.makeText(this, "ユーザ登録が完了しました！", Toast.LENGTH_SHORT).show()
+                    val intent = Intent(this, HomeActivity::class.java)
+                    startActivity(intent)
+                }
+                .addOnFailureListener {
+                    Log.d("RegisterActivity", "Failed to create user: ${it.message}")
+                    Toast.makeText(this, it.message.toString(), Toast.LENGTH_SHORT).show()
+                }
+
+    }
+
+    private fun verifyInputData(userId: String, name: String, email: String, password: String) {
+        val limitUserNameLength = 20        // ユーザが登録できる名前の長さの限界
 
         if (userId.isEmpty()) {
             Toast.makeText(this, "UserIDを入力してください", Toast.LENGTH_SHORT).show()
@@ -87,29 +114,6 @@ class RegistrationActivity : AppCompatActivity() {
             Toast.makeText(this, "Passwordを入力してください", Toast.LENGTH_SHORT).show()
             return
         }
-
-        // FirebaseAuthを用いたアカウント作成
-        FirebaseAuth.getInstance().createUserWithEmailAndPassword(email, password)
-                .addOnCompleteListener {
-                    if (!it.isSuccessful) return@addOnCompleteListener
-
-                    // ユーザ登録に成功した場合
-                    Log.d("RegisterActivity", "Successfully created user with uid: ${it.result.user.uid}")
-                    userUID = it.result.user.uid
-
-                    // 登録したユーザアイコンをFirebaseのストレージに保存する
-                    // 実際はFirebaseではなく、しかるべき場所(EC2?)に保存するなどする
-                    uploadImageToFirebaseStorage()
-
-                    Toast.makeText(this, "ユーザ登録が完了しました！", Toast.LENGTH_SHORT).show()
-                    val intent = Intent(this, HomeActivity::class.java)
-                    startActivity(intent)
-                }
-                .addOnFailureListener {
-                    Log.d("RegisterActivity", "Failed to create user: ${it.message}")
-                    Toast.makeText(this, it.message.toString(), Toast.LENGTH_SHORT).show()
-                }
-
     }
 
 

--- a/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
@@ -14,6 +14,8 @@ import com.google.firebase.storage.FirebaseStorage
 import kotlinx.android.synthetic.main.activity_registration.*
 import java.util.*
 
+const val LIMIT_USER_NAME_LENGTH = 20        // ユーザが登録できる名前の長さの限界
+
 class RegistrationActivity : AppCompatActivity() {
     var selectedPhotoUri: Uri? = null   // アイコンにするために選択した画像のURI
     var userUID: String? = null         // Firebaseで発行されるUID
@@ -93,8 +95,6 @@ class RegistrationActivity : AppCompatActivity() {
     }
 
     private fun isValidInputData(userId: String, name: String, email: String, password: String): Boolean {
-        val limitUserNameLength = 20        // ユーザが登録できる名前の長さの限界
-
         if (userId.isEmpty()) {
             Toast.makeText(this, "UserIDを入力してください", Toast.LENGTH_SHORT).show()
             return false
@@ -110,8 +110,8 @@ class RegistrationActivity : AppCompatActivity() {
             return false
         }
 
-        if (name.length > limitUserNameLength) {
-            Toast.makeText(this, "名前は${limitUserNameLength}文字以内にしてください", Toast.LENGTH_SHORT).show()
+        if (name.length > LIMIT_USER_NAME_LENGTH) {
+            Toast.makeText(this, "名前は${LIMIT_USER_NAME_LENGTH}文字以内にしてください", Toast.LENGTH_SHORT).show()
             return false
         }
 

--- a/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
@@ -61,7 +61,7 @@ class RegistrationActivity : AppCompatActivity() {
         val email = email_edittext_register.text.toString()
         val password = password_edittext_register.text.toString()
 
-        verifyInputData(userId, name, email, password)
+        if (!isValidInputData(userId, name, email, password)) return
 
         // FirebaseAuthを用いたアカウント作成
         FirebaseAuth.getInstance().createUserWithEmailAndPassword(email, password)
@@ -87,33 +87,35 @@ class RegistrationActivity : AppCompatActivity() {
 
     }
 
-    private fun verifyInputData(userId: String, name: String, email: String, password: String) {
+    private fun isValidInputData(userId: String, name: String, email: String, password: String): Boolean {
         val limitUserNameLength = 20        // ユーザが登録できる名前の長さの限界
 
         if (userId.isEmpty()) {
             Toast.makeText(this, "UserIDを入力してください", Toast.LENGTH_SHORT).show()
-            return
+            return false
         }
 
         if (name.isEmpty()) {
             Toast.makeText(this, "Nameを入力してください", Toast.LENGTH_SHORT).show()
-            return
+            return false
         }
 
         if (name.length > limitUserNameLength) {
             Toast.makeText(this, "名前は${limitUserNameLength}文字以内にしてください", Toast.LENGTH_SHORT).show()
-            return
+            return false
         }
 
         if (email.isEmpty()) {
             Toast.makeText(this, "Emailを入力してください", Toast.LENGTH_SHORT).show()
-            return
+            return false
         }
 
         if (password.isEmpty()) {
             Toast.makeText(this, "Passwordを入力してください", Toast.LENGTH_SHORT).show()
-            return
+            return false
         }
+
+        return true
     }
 
 

--- a/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
@@ -15,7 +15,6 @@ import kotlinx.android.synthetic.main.activity_registration.*
 import java.util.*
 
 class RegistrationActivity : AppCompatActivity() {
-
     var selectedPhotoUri: Uri? = null   // アイコンにするために選択した画像のURI
     var userUID: String? = null         // Firebaseで発行されるUID
 
@@ -57,6 +56,8 @@ class RegistrationActivity : AppCompatActivity() {
     }
 
     private fun performRegister() {
+        val limitUserNameLength = 20        // ユーザが登録できる名前の長さの限界
+
         val userId = userid_edittext_register.text.toString()
         val name = username_edittext_register.text.toString()
         val email = email_edittext_register.text.toString()
@@ -69,6 +70,11 @@ class RegistrationActivity : AppCompatActivity() {
 
         if (name.isEmpty()) {
             Toast.makeText(this, "Nameを入力してください", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        if (name.length > limitUserNameLength) {
+            Toast.makeText(this, "名前は${limitUserNameLength}文字以内にしてください", Toast.LENGTH_SHORT).show()
             return
         }
 

--- a/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
@@ -57,13 +57,28 @@ class RegistrationActivity : AppCompatActivity() {
     }
 
     private fun performRegister() {
+        val userId = userid_edittext_register.text.toString()
+        val name = username_edittext_register.text.toString()
         val email = email_edittext_register.text.toString()
         val password = password_edittext_register.text.toString()
 
-        // emailまたはpasswordが空だとFirebase登録時にアプリが強制終了してしまうので
-        // emptyであるかどうかをチェックしている
-        if (email.isEmpty() || password.isEmpty()) {
-            Toast.makeText(this, "EmailまたはPasswordを入力してください", Toast.LENGTH_SHORT).show()
+        if (userId.isEmpty()) {
+            Toast.makeText(this, "UserIDを入力してください", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        if (name.isEmpty()) {
+            Toast.makeText(this, "Nameを入力してください", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        if (email.isEmpty()) {
+            Toast.makeText(this, "Emailを入力してください", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        if (password.isEmpty()) {
+            Toast.makeText(this, "Passwordを入力してください", Toast.LENGTH_SHORT).show()
             return
         }
 

--- a/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
@@ -95,6 +95,11 @@ class RegistrationActivity : AppCompatActivity() {
             return false
         }
 
+        if (isAlreadyRegistered(userId)) {
+            Toast.makeText(this, "このUserIDは既に登録されています", Toast.LENGTH_SHORT).show()
+            return false
+        }
+
         if (name.isEmpty()) {
             Toast.makeText(this, "Nameを入力してください", Toast.LENGTH_SHORT).show()
             return false
@@ -116,6 +121,11 @@ class RegistrationActivity : AppCompatActivity() {
         }
 
         return true
+    }
+
+    private fun isAlreadyRegistered(userId: String): Boolean {
+        // TODO: サーバのDBにアクセスして、userIdが既に登録していないか確かめる
+        return false
     }
 
 

--- a/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
@@ -72,6 +72,11 @@ class RegistrationActivity : AppCompatActivity() {
                     Log.d("RegisterActivity", "Successfully created user with uid: ${it.result.user.uid}")
                     userUID = it.result.user.uid
 
+                    if (selectedPhotoUri == null) {
+                        Log.d("RegistrationActivity", "アイコンが選択されていないのでデフォルトアイコンを設定する")
+                        // TODO: デフォルトアイコンを設定する
+                    }
+
                     // 登録したユーザアイコンをFirebaseのストレージに保存する
                     // 実際はFirebaseではなく、しかるべき場所(EC2?)に保存するなどする
                     uploadImageToFirebaseStorage()

--- a/android-client/app/src/main/res/layout/activity_registration.xml
+++ b/android-client/app/src/main/res/layout/activity_registration.xml
@@ -8,12 +8,27 @@
     tools:context=".RegistrationActivity">
 
     <EditText
+        android:id="@+id/userid_edittext_register"
+        android:layout_width="0dp"
+        android:layout_height="50dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        android:background="@android:color/white"
+        android:ems="10"
+        android:hint="UserID"
+        android:inputType="textPersonName"
+        android:paddingLeft="12dp"
+        android:paddingRight="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/selectphoto_imageview_register" />
+
+    <EditText
         android:id="@+id/username_edittext_register"
         android:layout_width="0dp"
         android:layout_height="50dp"
         android:layout_marginEnd="8dp"
-        android:layout_marginLeft="8dp"
-        android:layout_marginRight="8dp"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:background="@android:color/white"
@@ -24,7 +39,7 @@
         android:paddingRight="12dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/select_photo_button_register" />
+        app:layout_constraintTop_toBottomOf="@+id/userid_edittext_register" />
 
     <EditText
         android:id="@+id/email_edittext_register"


### PR DESCRIPTION
# 概要
この前話し合ったところを修正しておきました。
量もそんなに多くないのでさらっとレビューしていただければOKです。

- ユーザに一意なIDも登録してもらうことにしたため、それを入力する欄を追加
- ユーザの名前に制限をつけた（適当に20文字）
- アイコンが選択されていないときの分岐を追加
- etc