### PR TITLE
[add]minSdkVersionによって2つのflavorに分けた

### DIFF
--- a/android-client/app/build.gradle
+++ b/android-client/app/build.gradle
@@ -14,7 +14,6 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.sample.android_client"
-        minSdkVersion 26
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
@@ -24,6 +23,19 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    flavorDimensions "api"
+
+    productFlavors {
+        minApi26 {
+            dimension "api"
+            minSdkVersion 26
+        }
+        minApi24 {
+            dimension "api"
+            minSdkVersion 24
         }
     }
 }


### PR DESCRIPTION
# 概要
今まで通り普段の開発用(minSdkVersion26)と、私が実機でテストしたいとき用(minSdkVersion24)の2つのflavorをgradleに設定しました

# flavorの切り替え方
メニューバーからBuild -> Select Build Variantを選択すると、画像のように左側にBuild Variantを選択するウィンドウが表示されます。今まで通りならminApi26Debug、Android7.0端末でテストするときはminApi24Debugを選択します。

![flavor](https://user-images.githubusercontent.com/24669535/45263008-8c61a300-b45c-11e8-9e6c-4a32fbbef6b1.PNG)
