### PR TITLE
新規グループ作成画面にアイコン選択ボタンを追加

### DIFF
--- a/android-client/app/src/main/AndroidManifest.xml
+++ b/android-client/app/src/main/AndroidManifest.xml
@@ -21,10 +21,12 @@
         <activity
             android:name=".TalkActivity"
             android:label="@string/title_activity_talk" />
-        <activity android:name=".CreateGroupActivity">
+        <activity
+            android:name=".CreateGroupActivity"
+            android:windowSoftInputMode="stateAlwaysHidden">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value=".HomeActivity"/>
+                android:value=".HomeActivity" />
         </activity>
     </application>
 

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -80,6 +80,11 @@ class CreateGroupActivity : AppCompatActivity() {
                 return@setOnClickListener
             }
 
+            if (selectedPhotoUri == null) {
+                Log.d("CreateGroupActivity", "アイコンが選択されていない")
+                // TODO: アイコンが選ばれていないときにデフォルトアイコンを設定する？
+            }
+
             // TODO: 選択されたユーザのリストで新しくグループを作ってサーバのDBに登録する処理
             // TODO: ローカルDBに登録する処理
 

--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -1,6 +1,10 @@
 package com.sample.android_client
 
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.provider.MediaStore
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.GridLayoutManager
 import android.support.v7.widget.LinearLayoutManager
@@ -12,9 +16,11 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.kotlinandroidextensions.Item
 import com.xwray.groupie.kotlinandroidextensions.ViewHolder
 import kotlinx.android.synthetic.main.activity_create_group.*
+import kotlinx.android.synthetic.main.activity_registration.*
 import kotlinx.android.synthetic.main.item_friend_friends.*
 
 class CreateGroupActivity : AppCompatActivity() {
+    var selectedPhotoUri: Uri? = null
     val groupAdapter = GroupAdapter<ViewHolder>().apply {
         spanCount = 4
     }
@@ -97,6 +103,26 @@ class CreateGroupActivity : AppCompatActivity() {
             sItem.notifyChanged()
             updateGuideTextview()
             updateScrollView()
+        }
+
+        select_photo_button_create_group.setOnClickListener {
+            val intent = Intent(Intent.ACTION_PICK)
+            intent.type = "image/*"
+            startActivityForResult(intent, 0)
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        // 画像選択に成功した場合
+        if (requestCode == 0 && resultCode == Activity.RESULT_OK && data != null) {
+            selectedPhotoUri = data.data
+            val bitmap = MediaStore.Images.Media.getBitmap(contentResolver, selectedPhotoUri)
+
+            // 選択した画像を円形に表示する(最初に表示されていた丸は邪魔になるので透明にしている)
+            select_photo_button_create_group.alpha = 0f
+            circular_imageview_create_group.setImageBitmap(bitmap)
         }
     }
 

--- a/android-client/app/src/main/res/drawable/circular_button_create_group.xml
+++ b/android-client/app/src/main/res/drawable/circular_button_create_group.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/holo_green_light"/>
+    <corners android:radius="50dp"/>
+</shape>

--- a/android-client/app/src/main/res/layout/activity_create_group.xml
+++ b/android-client/app/src/main/res/layout/activity_create_group.xml
@@ -123,6 +123,7 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <de.hdodenhof.circleimageview.CircleImageView
+        android:id="@+id/circular_imageview_create_group"
         android:layout_width="100dp"
         android:layout_height="100dp"
         app:layout_constraintBottom_toBottomOf="@+id/select_photo_button_create_group"

--- a/android-client/app/src/main/res/layout/activity_create_group.xml
+++ b/android-client/app/src/main/res/layout/activity_create_group.xml
@@ -17,7 +17,7 @@
         android:hint="グループ名"
         android:inputType="text"
         android:paddingHorizontal="8dp"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/select_photo_button_create_group"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -44,7 +44,7 @@
         android:hint="友達の名前を検索"
         android:inputType="textPersonName"
         android:paddingHorizontal="8dp"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/select_photo_button_create_group"
         app:layout_constraintStart_toEndOf="@+id/delete_button_create_group"
         app:layout_constraintTop_toBottomOf="@+id/group_name_edittext_create_group" />
 
@@ -107,6 +107,28 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
+
+    <Button
+        android:id="@+id/select_photo_button_create_group"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/circular_button_create_group"
+        android:text="アイコンを選択"
+        android:textSize="12sp"
+        app:layout_constraintBottom_toTopOf="@+id/guide_textview_create_group"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <de.hdodenhof.circleimageview.CircleImageView
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        app:layout_constraintBottom_toBottomOf="@+id/select_photo_button_create_group"
+        app:layout_constraintEnd_toEndOf="@+id/select_photo_button_create_group"
+        app:layout_constraintStart_toStartOf="@+id/select_photo_button_create_group"
+        app:layout_constraintTop_toTopOf="@+id/select_photo_button_create_group" />
 
 
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
issue #34 

# 概要
新規グループ作成画面にアイコンを選んで表示する奴を実装しました。
基本的に実装方法としてはユーザ登録画面にある奴と全く一緒です。
ついでに新規グループ作成画面に遷移したときにキーボードがせりあがってくるのが邪魔かなと感じたのでそうならないようにしました。

<img src="https://user-images.githubusercontent.com/24669535/45263929-fd5d8680-b46d-11e8-9ea5-6be8034fcd1e.png" width=50%>
