### PR TITLE
友達画面に検索機能を追加

### DIFF
--- a/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/CreateGroupActivity.kt
@@ -6,13 +6,13 @@ import android.support.v7.widget.GridLayoutManager
 import android.support.v7.widget.LinearLayoutManager
 import android.text.Editable
 import android.text.TextWatcher
-import android.util.Log
 import android.widget.Toast
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.kotlinandroidextensions.Item
 import com.xwray.groupie.kotlinandroidextensions.ViewHolder
 import kotlinx.android.synthetic.main.activity_create_group.*
 import kotlinx.android.synthetic.main.item_friend_friends.*
+import kotlinx.android.synthetic.main.item_user_scroll.*
 
 class CreateGroupActivity : AppCompatActivity() {
     val groupAdapter = GroupAdapter<ViewHolder>().apply {
@@ -49,7 +49,7 @@ class CreateGroupActivity : AppCompatActivity() {
             adapter = hGroupAdapter
         }
 
-        search_box_create_group.addTextChangedListener(object: TextWatcher {
+        search_box_create_group.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(p0: Editable?) {
                 displaySearchedUser(p0.toString())
             }
@@ -149,7 +149,7 @@ class CreateGroupActivity : AppCompatActivity() {
                                    val userIconId: Int,
                                    var isSelected: Boolean = false) : Item() {
         override fun bind(viewHolder: com.xwray.groupie.kotlinandroidextensions.ViewHolder, position: Int) {
-            viewHolder.user_name_textview_scroll.text = userName
+            viewHolder.user_name_textview_friends.text = userName
             viewHolder.itemView.alpha = if (isSelected) 1f else 0.6f
             // TODO : 友達のアイコンを表示する
         }

--- a/android-client/app/src/main/java/com/sample/android_client/DBHelper.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/DBHelper.kt
@@ -35,7 +35,7 @@ class DBHelper(context: Context) : ManagedSQLiteOpenHelper(context, DATABASE_NAM
         db.createTable(ROOMS_TABLE_NAME, true,
                 "id" to INTEGER + PRIMARY_KEY + AUTOINCREMENT,
                 "server_id" to INTEGER + UNIQUE + NOT_NULL,
-                "icon_id" to INTEGER  + NOT_NULL,
+                "icon_id" to INTEGER + NOT_NULL,
                 "name" to TEXT + NOT_NULL,
                 "is_group" to INTEGER + NOT_NULL)
 
@@ -50,6 +50,81 @@ class DBHelper(context: Context) : ManagedSQLiteOpenHelper(context, DATABASE_NAM
                 "server_id" to 1,
                 "icon_id" to 1,
                 "name" to "sample2",
+                "is_group" to 0)
+
+
+        // 少し増やす
+
+        db.insert(ROOMS_TABLE_NAME,
+                "server_id" to 2,
+                "icon_id" to 1,
+                "name" to "suzuki taro",
+                "is_group" to 0)
+
+        db.insert(ROOMS_TABLE_NAME,
+                "server_id" to 3,
+                "icon_id" to 1,
+                "name" to "suzuki jiro",
+                "is_group" to 0)
+
+        db.insert(ROOMS_TABLE_NAME,
+                "server_id" to 4,
+                "icon_id" to 1,
+                "name" to "suzuki saburo",
+                "is_group" to 0)
+
+        db.insert(ROOMS_TABLE_NAME,
+                "server_id" to 5,
+                "icon_id" to 1,
+                "name" to "suzuki siro",
+                "is_group" to 0)
+
+        db.insert(ROOMS_TABLE_NAME,
+                "server_id" to 6,
+                "icon_id" to 1,
+                "name" to "honda taro",
+                "is_group" to 0)
+
+        db.insert(ROOMS_TABLE_NAME,
+                "server_id" to 7,
+                "icon_id" to 1,
+                "name" to "honda jiro",
+                "is_group" to 0)
+
+        db.insert(ROOMS_TABLE_NAME,
+                "server_id" to 8,
+                "icon_id" to 1,
+                "name" to "honda saburo",
+                "is_group" to 0)
+
+        db.insert(ROOMS_TABLE_NAME,
+                "server_id" to 9,
+                "icon_id" to 1,
+                "name" to "honda siro",
+                "is_group" to 0)
+
+        db.insert(ROOMS_TABLE_NAME,
+                "server_id" to 10,
+                "icon_id" to 1,
+                "name" to "kawasaki taro",
+                "is_group" to 0)
+
+        db.insert(ROOMS_TABLE_NAME,
+                "server_id" to 11,
+                "icon_id" to 1,
+                "name" to "kawasaki jiro",
+                "is_group" to 0)
+
+        db.insert(ROOMS_TABLE_NAME,
+                "server_id" to 12,
+                "icon_id" to 1,
+                "name" to "kawasaki saburo",
+                "is_group" to 0)
+
+        db.insert(ROOMS_TABLE_NAME,
+                "server_id" to 13,
+                "icon_id" to 1,
+                "name" to "kawasaki siro",
                 "is_group" to 0)
     }
 

--- a/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
@@ -5,6 +5,8 @@ import android.content.Intent
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v7.widget.GridLayoutManager
+import android.text.Editable
+import android.text.TextWatcher
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -58,6 +60,22 @@ class FriendsFragment : Fragment() {
             // TODO: 新しいグループを作成する処理を書く
             // 新しいアクティビティ(CreateGroupActivity)を作ってそこに飛ぶか
         }
+
+        search_friends_edittext_friends.addTextChangedListener(object: TextWatcher {
+            override fun afterTextChanged(p0: Editable?) {
+                if (p0.isNullOrEmpty()) {
+                    displayGroupsAndFriends()
+                    return
+                }
+                displaySearchedFriends(p0.toString())
+            }
+
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+            }
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+            }
+        })
 
         search_friends_button_friends.setOnClickListener {
             val text = search_friends_edittext_friends.text.toString()

--- a/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
@@ -23,6 +23,9 @@ class FriendsFragment : Fragment() {
     private val groupAdapter = GroupAdapter<ViewHolder>().apply {
         spanCount = 4
     }
+    private lateinit var rooms: List<Room>
+    private lateinit var friends: List<RoomItem>
+    private lateinit var groups: List<RoomItem>
 
     override fun onAttach(context: Context?) {
         super.onAttach(context)
@@ -35,6 +38,11 @@ class FriendsFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        // 友達画面に遷移してきたときに一回だけやればOKのはず
+        getRooms()
+        createFriendItems()
+        createGroupItems()
 
         displayGroupsAndFriends()
 
@@ -60,10 +68,6 @@ class FriendsFragment : Fragment() {
     }
 
     private fun displayGroupsAndFriends() {
-        val rooms = getRooms()
-        val groups = createGroupItems(rooms)
-        val friends = createFriendItems(rooms)
-
         recycler_view_friends.apply {
             layoutManager = GridLayoutManager(activity, groupAdapter.spanCount).apply {
                 spanSizeLookup = groupAdapter.spanSizeLookup
@@ -90,8 +94,7 @@ class FriendsFragment : Fragment() {
 
     }
 
-    private fun getRooms(): List<Room> {
-        var rooms = listOf<Room>()
+    private fun getRooms() {
         database.use {
             rooms = this.select(ROOMS_TABLE_NAME).exec {
                 val parser = rowParser { id: Int, serverId: Int, iconId: Int, name: String, isGroup: Int ->
@@ -101,18 +104,15 @@ class FriendsFragment : Fragment() {
             }
         }
         Log.d("FriendsFragment", rooms.size.toString())
-        return rooms
     }
 
-    private fun createGroupItems(groups: List<Room>): MutableList<RoomItem> {
-        return groups.filter { it.isGroup }
+    private fun createGroupItems() {
+        groups = rooms.filter { it.isGroup }
                 .map { it -> RoomItem(it.id, it.name, it.iconId) }
-                .toMutableList()
     }
 
-    private fun createFriendItems(groups: List<Room>): MutableList<RoomItem> {
-        return groups.filter { !(it.isGroup) }
+    private fun createFriendItems() {
+        friends = rooms.filter { !(it.isGroup) }
                 .map { it -> RoomItem(it.id, it.name, it.iconId) }
-                .toMutableList()
     }
 }

--- a/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
@@ -61,7 +61,7 @@ class FriendsFragment : Fragment() {
             // 新しいアクティビティ(CreateGroupActivity)を作ってそこに飛ぶか
         }
 
-        search_friends_edittext_friends.addTextChangedListener(object: TextWatcher {
+        search_friends_edittext_friends.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(p0: Editable?) {
                 if (p0.isNullOrEmpty()) {
                     displayGroupsAndFriends()
@@ -76,11 +76,6 @@ class FriendsFragment : Fragment() {
             override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
             }
         })
-
-        search_friends_button_friends.setOnClickListener {
-            val text = search_friends_edittext_friends.text.toString()
-            displaySearchedFriends(text)
-        }
 
         create_group_button_friends.setOnClickListener {
             val intent = Intent(activity, CreateGroupActivity::class.java)

--- a/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
@@ -55,12 +55,6 @@ class FriendsFragment : Fragment() {
 
         displayGroupsAndFriends()
 
-        create_group_button_friends.setOnClickListener {
-            Log.d("FriendsFragment", "新しいグループを作成する")
-            // TODO: 新しいグループを作成する処理を書く
-            // 新しいアクティビティ(CreateGroupActivity)を作ってそこに飛ぶか
-        }
-
         search_friends_edittext_friends.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(p0: Editable?) {
                 if (p0.isNullOrEmpty()) {

--- a/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
@@ -61,11 +61,6 @@ class FriendsFragment : Fragment() {
 
         search_friends_button_friends.setOnClickListener {
             val text = search_friends_edittext_friends.text.toString()
-            Log.d("FriendsFragment", "文字列${text}を含むユーザーを検索する")
-            // TODO: 文字列textを含むユーザーを検索してリストアップする処理を書く
-            // アクティビティを分けて、そっちに遷移するようにするのが楽そうだけど
-            // このページ内でシュッっと画面が切り替わるようにしたほうがかっこいい
-            // 文字を入力するたびリアルタイムで検索していくとかもかっこいいけど難しそう
             displaySearchedFriends(text)
         }
 
@@ -108,8 +103,6 @@ class FriendsFragment : Fragment() {
             add(Section(friends))
             groupAdapter.add(this)
         }
-
-        Log.d("FriendsFragment", groupAdapter.getItem(0).toString())
     }
 
     private fun getRooms() {
@@ -121,7 +114,6 @@ class FriendsFragment : Fragment() {
                 parseList(parser)
             }
         }
-        Log.d("FriendsFragment", rooms.size.toString())
     }
 
     private fun createGroupItems() {

--- a/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
@@ -100,6 +100,7 @@ class FriendsFragment : Fragment() {
                 parseList(parser)
             }
         }
+        Log.d("FriendsFragment", rooms.size.toString())
         return rooms
     }
 

--- a/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
@@ -39,6 +39,13 @@ class FriendsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        recycler_view_friends.apply {
+            layoutManager = GridLayoutManager(activity, groupAdapter.spanCount).apply {
+                spanSizeLookup = groupAdapter.spanSizeLookup
+            }
+            adapter = groupAdapter
+        }
+
         // 友達画面に遷移してきたときに一回だけやればOKのはず
         getRooms()
         createFriendItems()
@@ -59,21 +66,38 @@ class FriendsFragment : Fragment() {
             // アクティビティを分けて、そっちに遷移するようにするのが楽そうだけど
             // このページ内でシュッっと画面が切り替わるようにしたほうがかっこいい
             // 文字を入力するたびリアルタイムで検索していくとかもかっこいいけど難しそう
+            displaySearchedFriends(text)
         }
 
         create_group_button_friends.setOnClickListener {
             val intent = Intent(activity, CreateGroupActivity::class.java)
             startActivity(intent)
         }
+
+        groupAdapter.setOnItemClickListener { item, view ->
+            Log.d("FriendsFragment", item.toString())
+            // TODO: 選択したルームでのトークに遷移する
+        }
+    }
+
+    private fun displaySearchedFriends(keyword: String) {
+        if (keyword.isEmpty()) {
+            displayGroupsAndFriends()
+            return
+        }
+
+        groupAdapter.clear()
+
+        val searchedFriends = friends.filter { it.roomName.indexOf(keyword) >= 0 }
+
+        ExpandableGroup(ExpandableHeaderItem("個人間トーク"), true).apply {
+            add(Section(searchedFriends))
+            groupAdapter.add(this)
+        }
     }
 
     private fun displayGroupsAndFriends() {
-        recycler_view_friends.apply {
-            layoutManager = GridLayoutManager(activity, groupAdapter.spanCount).apply {
-                spanSizeLookup = groupAdapter.spanSizeLookup
-            }
-            adapter = groupAdapter
-        }
+        groupAdapter.clear()
 
         ExpandableGroup(ExpandableHeaderItem("グループトーク"), true).apply {
             add(Section(groups))
@@ -86,12 +110,6 @@ class FriendsFragment : Fragment() {
         }
 
         Log.d("FriendsFragment", groupAdapter.getItem(0).toString())
-
-        groupAdapter.setOnItemClickListener { item, view ->
-            Log.d("FriendsFragment", item.toString())
-            // TODO: 選択したルームでのトークに遷移する
-        }
-
     }
 
     private fun getRooms() {

--- a/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
@@ -76,6 +76,10 @@ class FriendsFragment : Fragment() {
             startActivity(intent)
         }
 
+        delete_button_friends.setOnClickListener {
+            search_friends_edittext_friends.text.clear()
+        }
+
         groupAdapter.setOnItemClickListener { item, view ->
             Log.d("FriendsFragment", item.toString())
             // TODO: 選択したルームでのトークに遷移する

--- a/android-client/app/src/main/java/com/sample/android_client/RoomItem.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/RoomItem.kt
@@ -4,12 +4,18 @@ import com.xwray.groupie.kotlinandroidextensions.Item
 import com.xwray.groupie.kotlinandroidextensions.ViewHolder
 import kotlinx.android.synthetic.main.item_friend_friends.*
 
+const val LIMIT_DISPLAY_NAME_LENGTH = 13
 
 data class RoomItem(val roomId: Int,
                     val roomName: String,
                     val roomIconId: Int) : Item() {
     override fun bind(viewHolder: ViewHolder, position: Int) {
-        viewHolder.user_name_textview_scroll.text = roomName
+        viewHolder.user_name_textview_friends.text = if (roomName.length <= LIMIT_DISPLAY_NAME_LENGTH) {
+            roomName
+        } else {
+            roomName.substring(0..10) + ".."
+        }
+
         // TODO : 相手のアイコンまたはグループアイコンを表示する
     }
 

--- a/android-client/app/src/main/res/layout/fragment_friends.xml
+++ b/android-client/app/src/main/res/layout/fragment_friends.xml
@@ -20,36 +20,27 @@
         android:layout_width="0dp"
         android:layout_height="50dp"
         android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:ems="10"
         android:hint="友だちを検索"
         android:inputType="textPersonName"
         android:paddingLeft="12dp"
         android:paddingRight="12dp"
-        app:layout_constraintEnd_toStartOf="@+id/search_friends_button_friends"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <Button
-        android:id="@+id/search_friends_button_friends"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginTop="8dp"
-        android:text="検索"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/create_group_button_friends"
         app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/create_group_button_friends"
-        android:layout_width="0dp"
+        android:layout_width="70dp"
         android:layout_height="50dp"
-        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:text="グループを作成"
         android:textSize="8sp"
-        app:layout_constraintEnd_toStartOf="@+id/search_friends_edittext_friends"
-        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintBottom_toTopOf="@+id/recycler_view_friends"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 </android.support.constraint.ConstraintLayout>

--- a/android-client/app/src/main/res/layout/fragment_friends.xml
+++ b/android-client/app/src/main/res/layout/fragment_friends.xml
@@ -27,7 +27,7 @@
         android:inputType="textPersonName"
         android:paddingLeft="12dp"
         android:paddingRight="12dp"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/delete_button_friends"
         app:layout_constraintStart_toEndOf="@+id/create_group_button_friends"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -43,4 +43,16 @@
         app:layout_constraintBottom_toTopOf="@+id/recycler_view_friends"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageButton
+        android:id="@+id/delete_button_friends"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="@+id/search_friends_edittext_friends"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/search_friends_edittext_friends"
+        app:srcCompat="@android:drawable/ic_delete" />
 </android.support.constraint.ConstraintLayout>

--- a/android-client/app/src/main/res/layout/item_friend_friends.xml
+++ b/android-client/app/src/main/res/layout/item_friend_friends.xml
@@ -7,7 +7,7 @@
     android:layout_height="wrap_content">
 
     <ImageView
-        android:id="@+id/user_icon_imageview_scroll"
+        android:id="@+id/user_icon_imageview_friends"
         android:layout_width="50dp"
         android:layout_height="50dp"
         android:layout_marginEnd="8dp"
@@ -19,7 +19,7 @@
         app:srcCompat="@android:drawable/btn_star_big_on" />
 
     <TextView
-        android:id="@+id/user_name_textview_scroll"
+        android:id="@+id/user_name_textview_friends"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
@@ -28,7 +28,7 @@
         android:layout_marginTop="8dp"
         android:text="user_name"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="@+id/user_icon_imageview_scroll"
-        app:layout_constraintStart_toStartOf="@+id/user_icon_imageview_scroll"
-        app:layout_constraintTop_toBottomOf="@+id/user_icon_imageview_scroll" />
+        app:layout_constraintEnd_toEndOf="@+id/user_icon_imageview_friends"
+        app:layout_constraintStart_toStartOf="@+id/user_icon_imageview_friends"
+        app:layout_constraintTop_toBottomOf="@+id/user_icon_imageview_friends" />
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
# 概要
検索機能を追加しました。だいたい新規グループ作成画面のものと仕様は一緒です。
- キーボードの入力に応じてリアルタイムに検索
- 右のバツ印を押すと入力文字列が消える
- 検索結果にグループは含まれない（グループを検索することはなさそうなので）
- 空文字列で検索した場合は初期画面と同じように表示される

とっきーが作ってくれた関数をちょっと使いやすいように変えています。これはroomsなどをメンバ変数にして一回だけDBから取得して以降はDBにアクセスしなくても持ってこれるようにしたかったからです。

<img src="https://user-images.githubusercontent.com/24669535/45276513-c5058900-b4fd-11e8-9206-8d3aa490baca.png" width=50%>