### PR TITLE
過去のメッセージをローカルのデータベースから取得する

### DIFF
--- a/android-client/app/src/main/java/com/sample/android_client/DBHelper.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/DBHelper.kt
@@ -3,6 +3,8 @@ package com.sample.android_client
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import org.jetbrains.anko.db.*
+import java.sql.Timestamp
+import java.util.*
 
 const val DATABASE_NAME = "local_data.db"
 const val DATABASE_VERSION = 1
@@ -60,6 +62,27 @@ class DBHelper(context: Context) : ManagedSQLiteOpenHelper(context, DATABASE_NAM
                 "icon_id" to 1,
                 "name" to "sample2",
                 "is_group" to 0)
+
+        db.insert(MESSAGES_TABLE_NAME,
+                "server_id" to 0,
+                "room_id" to 0,
+                "user_id" to 1,
+                "body" to "this message was posted other room",
+                "posted_at" to Timestamp(Date().time).toString())
+
+        db.insert(MESSAGES_TABLE_NAME,
+                "server_id" to 1,
+                "room_id" to 1,
+                "user_id" to 1,
+                "body" to "this message was posted by yours",
+                "posted_at" to Timestamp(Date().time).toString())
+
+        db.insert(MESSAGES_TABLE_NAME,
+                "server_id" to 2,
+                "room_id" to 1,
+                "user_id" to 2,
+                "body" to "this message was posted by someone other than me",
+                "posted_at" to Timestamp(Date().time).toString())
     }
 
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {

--- a/android-client/app/src/main/java/com/sample/android_client/DBHelper.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/DBHelper.kt
@@ -48,7 +48,8 @@ class DBHelper(context: Context) : ManagedSQLiteOpenHelper(context, DATABASE_NAM
                 "room_id" to INTEGER + NOT_NULL,
                 "user_id" to INTEGER + NOT_NULL,
                 "body" to TEXT + NOT_NULL,
-                "posted_at" to TEXT)
+                "posted_at" to TEXT + NOT_NULL)
+
 
         // デバッグ用データを追加
         // TODO 今後削除する

--- a/android-client/app/src/main/java/com/sample/android_client/DBHelper.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/DBHelper.kt
@@ -8,6 +8,7 @@ const val DATABASE_NAME = "local_data.db"
 const val DATABASE_VERSION = 1
 const val USERS_TABLE_NAME = "users"
 const val ROOMS_TABLE_NAME = "rooms"
+const val MESSAGES_TABLE_NAME = "messages"
 
 class DBHelper(context: Context) : ManagedSQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
     companion object {
@@ -35,9 +36,17 @@ class DBHelper(context: Context) : ManagedSQLiteOpenHelper(context, DATABASE_NAM
         db.createTable(ROOMS_TABLE_NAME, true,
                 "id" to INTEGER + PRIMARY_KEY + AUTOINCREMENT,
                 "server_id" to INTEGER + UNIQUE + NOT_NULL,
-                "icon_id" to INTEGER  + NOT_NULL,
+                "icon_id" to INTEGER + NOT_NULL,
                 "name" to TEXT + NOT_NULL,
                 "is_group" to INTEGER + NOT_NULL)
+
+        db.createTable(MESSAGES_TABLE_NAME, true,
+                "id" to INTEGER + PRIMARY_KEY + AUTOINCREMENT,
+                "server_id" to INTEGER + UNIQUE + NOT_NULL,
+                "room_id" to INTEGER + NOT_NULL,
+                "user_id" to INTEGER + NOT_NULL,
+                "body" to TEXT + NOT_NULL,
+                "posted_at" to TEXT)
 
         // デバッグ用データを追加
         // TODO 今後削除する

--- a/android-client/app/src/main/java/com/sample/android_client/Message.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/Message.kt
@@ -1,5 +1,5 @@
 package com.sample.android_client
 
-import java.time.LocalDateTime
+import java.sql.Timestamp
 
-data class Message(val messageID: Int, val senderID: Int, val body: String, val sendTime: LocalDateTime)
+data class Message(val id: Int, val serverId: Int, val roomId: Int, val userId: Int, val body: String, val postedAt: Timestamp)

--- a/android-client/app/src/main/java/com/sample/android_client/MessageRecyclerViewAdapter.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/MessageRecyclerViewAdapter.kt
@@ -27,9 +27,9 @@ class MessageRecyclerViewAdapter(private val messageList: MutableList<Message>)
         //TODO 送信者が自分以外であるかを判定するようにする
         return when (messageList[position].userId) {
             1 ->
-                R.layout.message_text_left
-            2 ->
                 R.layout.message_text_right
+            2 ->
+                R.layout.message_text_left
             else ->
                 throw RuntimeException()
         }

--- a/android-client/app/src/main/java/com/sample/android_client/MessageRecyclerViewAdapter.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/MessageRecyclerViewAdapter.kt
@@ -9,23 +9,32 @@ import android.widget.TextView
 import java.text.SimpleDateFormat
 import java.util.*
 
-class MessageRecyclerViewAdapter(private val messageList: MutableList<Message>)
+class MessageRecyclerViewAdapter(private val messages: MutableList<Message>)
     : RecyclerView.Adapter<MessageRecyclerViewAdapter.BaseViewHolder>() {
 
-    private val messages: MutableList<Message> = messageList
+    fun setMessages(messages: List<Message>) {
+        this.messages.clear()
+        this.messages.addAll(messages)
+        notifyDataSetChanged()
+    }
+
+    fun addMessage(message: Message) {
+        messages.add(message)
+        notifyItemInserted(itemCount - 1)
+    }
 
     override fun onBindViewHolder(holder: BaseViewHolder, position: Int) {
         holder.bind(position)
     }
 
     override fun getItemCount(): Int {
-        return messageList.size
+        return messages.size
     }
 
     override fun getItemViewType(position: Int): Int {
 
         //TODO 送信者が自分以外であるかを判定するようにする
-        return when (messageList[position].userId) {
+        return when (messages[position].userId) {
             1 ->
                 R.layout.message_text_right
             2 ->

--- a/android-client/app/src/main/java/com/sample/android_client/MessageRecyclerViewAdapter.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/MessageRecyclerViewAdapter.kt
@@ -6,6 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import java.text.SimpleDateFormat
+import java.util.*
 
 class MessageRecyclerViewAdapter(private val messageList: MutableList<Message>)
     : RecyclerView.Adapter<MessageRecyclerViewAdapter.BaseViewHolder>() {
@@ -53,8 +55,11 @@ class MessageRecyclerViewAdapter(private val messageList: MutableList<Message>)
         private val sendTime: TextView = view.findViewById(R.id.send_time)
 
         open fun bind(position: Int) {
+            val dateFormat = SimpleDateFormat("HH:mm")
+            val formattedTime = dateFormat.format(Date(messages[position].postedAt.time))
+
             message.text = messages[position].body
-            sendTime.text = messages[position].postedAt.toString()
+            sendTime.text = formattedTime
         }
     }
 

--- a/android-client/app/src/main/java/com/sample/android_client/MessageRecyclerViewAdapter.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/MessageRecyclerViewAdapter.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
-import java.time.format.DateTimeFormatter
 
 class MessageRecyclerViewAdapter(private val messageList: MutableList<Message>)
     : RecyclerView.Adapter<MessageRecyclerViewAdapter.BaseViewHolder>() {
@@ -24,7 +23,7 @@ class MessageRecyclerViewAdapter(private val messageList: MutableList<Message>)
     override fun getItemViewType(position: Int): Int {
 
         //TODO 送信者が自分以外であるかを判定するようにする
-        return when (messageList[position].senderID) {
+        return when (messageList[position].userId) {
             1 ->
                 R.layout.message_text_left
             2 ->
@@ -55,7 +54,7 @@ class MessageRecyclerViewAdapter(private val messageList: MutableList<Message>)
 
         open fun bind(position: Int) {
             message.text = messages[position].body
-            sendTime.text = messages[position].sendTime.format(DateTimeFormatter.ofPattern("HH:MM"))
+            sendTime.text = messages[position].postedAt.toString()
         }
     }
 

--- a/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
@@ -16,8 +16,6 @@ class TalkActivity : Activity() {
     val Context.database: DBHelper
         get() = DBHelper.getInstance(applicationContext)
 
-    private var messages = mutableListOf<Message>()
-
     // TODO Activity起動時に代入するように変更する
     private var roomId = 1
 
@@ -25,7 +23,7 @@ class TalkActivity : Activity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_talk)
 
-        messages = loadPastMessages()
+        val messages = mutableListOf<Message>()
         talk_recycler_view.adapter = MessageRecyclerViewAdapter(messages)
         talk_recycler_view.layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
 
@@ -39,14 +37,19 @@ class TalkActivity : Activity() {
         }
     }
 
+
     override fun onStart() {
         super.onStart()
-        messages = loadPastMessages()
-        talk_recycler_view.adapter?.notifyDataSetChanged()
+
+        val pastMessages = loadPastMessages()
+        val recyclerViewAdapter = talk_recycler_view.adapter as MessageRecyclerViewAdapter
+
+        recyclerViewAdapter.setMessages(pastMessages)
     }
 
-    private fun loadPastMessages(): MutableList<Message> {
-        var pastMessages = mutableListOf<Message>()
+    private fun loadPastMessages(): List<Message> {
+        var pastMessages = listOf<Message>()
+
         database.use {
             pastMessages = this.select(MESSAGES_TABLE_NAME)
                     .whereArgs("room_id = {roomId}", "roomId" to roomId)
@@ -55,7 +58,7 @@ class TalkActivity : Activity() {
                             Message(id, serverId, roomId, userId, body, toTimeStamp(postedAt))
                         }
                         parseList(parser)
-                    }.toMutableList()
+                    }
         }
         return pastMessages
     }

--- a/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
@@ -25,8 +25,8 @@ class TalkActivity : Activity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_talk)
 
-        talk_recycler_view.adapter = MessageRecyclerViewAdapter(messages)
         messages = loadPastMessages()
+        talk_recycler_view.adapter = MessageRecyclerViewAdapter(messages)
         talk_recycler_view.layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
 
         send_button_talk.setOnClickListener {

--- a/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
@@ -1,22 +1,32 @@
 package com.sample.android_client
 
-import android.os.Bundle
 import android.app.Activity
+import android.content.Context
+import android.os.Bundle
 import android.support.v7.widget.LinearLayoutManager
 import android.util.Log
-
 import kotlinx.android.synthetic.main.activity_talk.*
-import java.time.LocalDateTime
+import org.jetbrains.anko.db.parseList
+import org.jetbrains.anko.db.rowParser
+import org.jetbrains.anko.db.select
+import java.sql.Timestamp
+import java.text.SimpleDateFormat
 
 class TalkActivity : Activity() {
+    val Context.database: DBHelper
+        get() = DBHelper.getInstance(applicationContext)
+
+    private var messages = mutableListOf<Message>()
+
+    // TODO Activity起動時に代入するように変更する
+    private var roomId = 1
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_talk)
 
-        val messages = mutableListOf<Message>()
-
         talk_recycler_view.adapter = MessageRecyclerViewAdapter(messages)
+        messages = loadPastMessages()
         talk_recycler_view.layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
 
         send_button_talk.setOnClickListener {
@@ -29,4 +39,29 @@ class TalkActivity : Activity() {
         }
     }
 
+    override fun onStart() {
+        super.onStart()
+        messages = loadPastMessages()
+        talk_recycler_view.adapter?.notifyDataSetChanged()
+    }
+
+    private fun loadPastMessages(): MutableList<Message> {
+        var pastMessages = mutableListOf<Message>()
+        database.use {
+            pastMessages = this.select(MESSAGES_TABLE_NAME)
+                    .whereArgs("room_id = {roomId}", "roomId" to roomId)
+                    .exec {
+                        var parser = rowParser { id: Int, serverId: Int, roomId: Int, userId: Int, body: String, postedAt: String ->
+                            Message(id, serverId, roomId, userId, body, toTimeStamp(postedAt))
+                        }
+                        parseList(parser)
+                    }.toMutableList()
+        }
+        return pastMessages
+    }
+
+    private fun toTimeStamp(time: String): Timestamp {
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+        return Timestamp(dateFormat.parse(time).time)
+    }
 }

--- a/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
@@ -15,8 +15,6 @@ class TalkActivity : Activity() {
         setContentView(R.layout.activity_talk)
 
         val messages = mutableListOf<Message>()
-        messages.add(Message(1, 1, "Test1", LocalDateTime.now()))
-        messages.add(Message(2, 2, "Test1", LocalDateTime.now()))
 
         talk_recycler_view.adapter = MessageRecyclerViewAdapter(messages)
         talk_recycler_view.layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)


### PR DESCRIPTION
issue #9 
## 目的
- トーク画面に入ったとき、これまでそのルームで投稿されたメッセージ一覧をローカルから取得する

## 変更の概要
- ローカルDBに過去のメッセージを格納するテーブルを定義
- データベース設計の変更に伴い、メッセージの情報を格納するクラスを変更
- recyclerViewの子の扱いを誤っていたため修正


## 実装方法
- ローカルのDBはSQLiteを使用
- SQLiteを楽に使用するためAnkoを使用した
https://github.com/Kotlin/anko/wiki/Anko-SQLite
- サーバーにメッセージが投稿された時刻posetedAtは、サーバーから受け取る際とデータベースから読みだして使用する際はTimestamp型で扱い、データベースに格納する際はtoStringする
