### PR TITLE
トーク画面内で投稿されたメッセージをローカルストレージに保存する

### DIFF
--- a/android-client/app/build.gradle
+++ b/android-client/app/build.gradle
@@ -64,6 +64,8 @@ dependencies {
 
     // https://github.com/hdodenhof/CircleImageView
     implementation 'de.hdodenhof:circleimageview:2.2.0'
+
+    implementation 'io.reactivex.rxjava2:rxkotlin:2.3.0'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/android-client/app/src/main/java/com/sample/android_client/DBHelper.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/DBHelper.kt
@@ -44,7 +44,8 @@ class DBHelper(context: Context) : ManagedSQLiteOpenHelper(context, DATABASE_NAM
 
         db.createTable(MESSAGES_TABLE_NAME, true,
                 "id" to INTEGER + PRIMARY_KEY + AUTOINCREMENT,
-                "server_id" to INTEGER + UNIQUE + NOT_NULL,
+                // TODO server_idにUNIQUE制約をつける
+                "server_id" to INTEGER + NOT_NULL,
                 "room_id" to INTEGER + NOT_NULL,
                 "user_id" to INTEGER + NOT_NULL,
                 "body" to TEXT + NOT_NULL,

--- a/android-client/app/src/main/java/com/sample/android_client/Message.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/Message.kt
@@ -2,4 +2,4 @@ package com.sample.android_client
 
 import java.sql.Timestamp
 
-data class Message(val id: Int, val serverId: Int, val roomId: Int, val userId: Int, val body: String, val postedAt: Timestamp)
+data class Message(val serverId: Int, val roomId: Int, val userId: Int, val body: String, val postedAt: Timestamp)

--- a/android-client/app/src/main/java/com/sample/android_client/MessageRecyclerViewAdapter.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/MessageRecyclerViewAdapter.kt
@@ -9,8 +9,10 @@ import android.widget.TextView
 import java.text.SimpleDateFormat
 import java.util.*
 
-class MessageRecyclerViewAdapter(private val messages: MutableList<Message>)
+class MessageRecyclerViewAdapter()
     : RecyclerView.Adapter<MessageRecyclerViewAdapter.BaseViewHolder>() {
+
+    val messages = mutableListOf<Message>()
 
     fun setMessages(messages: List<Message>) {
         this.messages.clear()

--- a/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
@@ -37,9 +37,8 @@ class TalkActivity : Activity() {
         }
     }
 
-
-    override fun onStart() {
-        super.onStart()
+    override fun onResume() {
+        super.onResume()
 
         val pastMessages = loadPastMessages()
         val recyclerViewAdapter = talk_recycler_view.adapter as MessageRecyclerViewAdapter

--- a/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
@@ -51,6 +51,7 @@ class TalkActivity : Activity() {
         super.onPause()
         Completable.fromAction { insertNewMessages(newMessages) }
                 .subscribeOn(Schedulers.io())
+                .observeOn(Schedulers.io())
                 .subscribe()
     }
 

--- a/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
@@ -51,11 +51,11 @@ class TalkActivity : Activity() {
         var pastMessages = listOf<Message>()
 
         database.use {
-            pastMessages = this.select(MESSAGES_TABLE_NAME)
+            pastMessages = this.select(MESSAGES_TABLE_NAME, "server_id", "room_id", "user_id", "body", "posted_at")
                     .whereArgs("room_id = {roomId}", "roomId" to roomId)
                     .exec {
-                        var parser = rowParser { id: Int, serverId: Int, roomId: Int, userId: Int, body: String, postedAt: String ->
-                            Message(id, serverId, roomId, userId, body, toTimeStamp(postedAt))
+                        var parser = rowParser { serverId: Int, roomId: Int, userId: Int, body: String, postedAt: String ->
+                            Message(serverId, roomId, userId, body, toTimeStamp(postedAt))
                         }
                         parseList(parser)
                     }

--- a/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
@@ -11,6 +11,7 @@ import kotlinx.android.synthetic.main.activity_talk.*
 import org.jetbrains.anko.db.*
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
+import java.util.*
 
 class TalkActivity : Activity() {
     val Context.database: DBHelper
@@ -33,6 +34,12 @@ class TalkActivity : Activity() {
             Log.d("TalkActivity", "文字列${message}を送信する")
             // TODO: message送信処理
             // 入力ボックスを空にする
+
+            // TODO デバッグ用、今後削除
+            val dummyMessage = createDummyMessage()
+            Log.d("TalkActivity", "userId = ${dummyMessage.userId} message=${dummyMessage.postedAt}")
+            newMessages.add(dummyMessage)
+
             input_message_box_talk.text.clear()
         }
     }
@@ -90,5 +97,13 @@ class TalkActivity : Activity() {
     private fun toTimeStamp(time: String): Timestamp {
         val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
         return Timestamp(dateFormat.parse(time).time)
+    }
+
+    //TODO デバッグ用、今後削除
+    private fun createDummyMessage(): Message {
+        val timeStamp = Timestamp(Date().time)
+        val userId = if (Random().nextBoolean()) 1 else 2
+
+        return Message(1, roomId, userId, timeStamp.toString(), timeStamp)
     }
 }

--- a/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
@@ -25,8 +25,7 @@ class TalkActivity : Activity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_talk)
 
-        val messages = mutableListOf<Message>()
-        talk_recycler_view.adapter = MessageRecyclerViewAdapter(messages)
+        talk_recycler_view.adapter = MessageRecyclerViewAdapter()
         talk_recycler_view.layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
 
         send_button_talk.setOnClickListener {
@@ -34,7 +33,6 @@ class TalkActivity : Activity() {
             Log.d("TalkActivity", "文字列${message}を送信する")
             // TODO: message送信処理
             // 入力ボックスを空にする
-            newMessages.add(messages.last())
             input_message_box_talk.text.clear()
         }
     }

--- a/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
@@ -19,14 +19,14 @@ class TalkActivity : Activity() {
 
     // TODO Activity起動時に代入するように変更する
     private var roomId = 1
-
     private val newMessages = mutableListOf<Message>()
+    private val talkAdapter = MessageRecyclerViewAdapter()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_talk)
 
-        talk_recycler_view.adapter = MessageRecyclerViewAdapter()
+        talk_recycler_view.adapter = talkAdapter
         talk_recycler_view.layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
 
         send_button_talk.setOnClickListener {
@@ -49,9 +49,7 @@ class TalkActivity : Activity() {
 
         newMessages.clear()
         val pastMessages = loadPastMessages()
-        val recyclerViewAdapter = talk_recycler_view.adapter as MessageRecyclerViewAdapter
-
-        recyclerViewAdapter.setMessages(pastMessages)
+        talkAdapter.setMessages(pastMessages)
     }
 
     override fun onPause() {

--- a/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
@@ -5,10 +5,10 @@ import android.content.Context
 import android.os.Bundle
 import android.support.v7.widget.LinearLayoutManager
 import android.util.Log
+import io.reactivex.Completable
+import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.activity_talk.*
-import org.jetbrains.anko.db.parseList
-import org.jetbrains.anko.db.rowParser
-import org.jetbrains.anko.db.select
+import org.jetbrains.anko.db.*
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
 
@@ -18,12 +18,14 @@ class TalkActivity : Activity() {
 
     // TODO Activity起動時に代入するように変更する
     private var roomId = 1
+    private val messages = mutableListOf<Message>()
+
+    var newMessagesCount = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_talk)
 
-        val messages = mutableListOf<Message>()
         talk_recycler_view.adapter = MessageRecyclerViewAdapter(messages)
         talk_recycler_view.layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
 
@@ -31,7 +33,7 @@ class TalkActivity : Activity() {
             val message = input_message_box_talk.text.toString()
             Log.d("TalkActivity", "文字列${message}を送信する")
             // TODO: message送信処理
-
+            newMessagesCount++
             // 入力ボックスを空にする
             input_message_box_talk.text.clear()
         }
@@ -40,10 +42,34 @@ class TalkActivity : Activity() {
     override fun onResume() {
         super.onResume()
 
+        newMessagesCount = 0
         val pastMessages = loadPastMessages()
         val recyclerViewAdapter = talk_recycler_view.adapter as MessageRecyclerViewAdapter
 
         recyclerViewAdapter.setMessages(pastMessages)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        Completable.fromAction { insertNewMessages(messages.takeLast(newMessagesCount)) }
+                .subscribeOn(Schedulers.io())
+                .subscribe()
+    }
+
+    private fun insertNewMessages(newMessages: List<Message>) {
+        database.use {
+            this.transaction {
+                newMessages.forEach {
+                    this.insert(MESSAGES_TABLE_NAME,
+                            "server_id" to it.serverId,
+                            "room_id" to it.roomId,
+                            "user_id" to it.userId,
+                            "body" to it.body,
+                            "posted_at" to it.postedAt.toString())
+
+                }
+            }
+        }
     }
 
     private fun loadPastMessages(): List<Message> {

--- a/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
@@ -18,14 +18,14 @@ class TalkActivity : Activity() {
 
     // TODO Activity起動時に代入するように変更する
     private var roomId = 1
-    private val messages = mutableListOf<Message>()
 
-    var newMessagesCount = 0
+    private val newMessages = mutableListOf<Message>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_talk)
 
+        val messages = mutableListOf<Message>()
         talk_recycler_view.adapter = MessageRecyclerViewAdapter(messages)
         talk_recycler_view.layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
 
@@ -33,8 +33,8 @@ class TalkActivity : Activity() {
             val message = input_message_box_talk.text.toString()
             Log.d("TalkActivity", "文字列${message}を送信する")
             // TODO: message送信処理
-            newMessagesCount++
             // 入力ボックスを空にする
+            newMessages.add(messages.last())
             input_message_box_talk.text.clear()
         }
     }
@@ -42,7 +42,7 @@ class TalkActivity : Activity() {
     override fun onResume() {
         super.onResume()
 
-        newMessagesCount = 0
+        newMessages.clear()
         val pastMessages = loadPastMessages()
         val recyclerViewAdapter = talk_recycler_view.adapter as MessageRecyclerViewAdapter
 
@@ -51,12 +51,12 @@ class TalkActivity : Activity() {
 
     override fun onPause() {
         super.onPause()
-        Completable.fromAction { insertNewMessages(messages.takeLast(newMessagesCount)) }
+        Completable.fromAction { insertNewMessages(newMessages) }
                 .subscribeOn(Schedulers.io())
                 .subscribe()
     }
 
-    private fun insertNewMessages(newMessages: List<Message>) {
+    private fun insertNewMessages(newMessages: MutableList<Message>) {
         database.use {
             this.transaction {
                 newMessages.forEach {


### PR DESCRIPTION
issue #39 

## 概要
- トーク画面を離れた際に、トーク画面にいた間に投稿されたメッセージを保存する

## 実装方法
- 新たに投稿されたメッセージを保持しておき、トーク画面を離れたときに、ローカルストレージに保存する
- 保存する処理は時間がかかるため、非同期で実行する
- 非同期処理を行う為Rxを利用した

## デバッグについて
- 送信ボタンを押すとダミーメッセージが作成され、ログが表示される
- トーク画面を一度離れ、再度入ると、ログと同様のデータがアプリ上にも表示されているのが確認できる
