### PR TITLE
メッセージ更新の問題を修正

### DIFF
--- a/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
@@ -21,6 +21,7 @@ import org.jetbrains.anko.db.rowParser
 import org.jetbrains.anko.db.select
 
 const val EXTRA_ROOM_ID = "roomId"
+const val EXTRA_ROOM_SERVER_ID = "roomServerId"
 
 class FriendsFragment : Fragment() {
     private val groupAdapter = GroupAdapter<ViewHolder>().apply {
@@ -52,8 +53,8 @@ class FriendsFragment : Fragment() {
         }
 
         val rooms = loadRooms()
-        friends = rooms.filter { !(it.isGroup) }.map { it.toRoomItem() }
-        groups = rooms.filter { it.isGroup }.map { it.toRoomItem() }
+        friends = rooms.asSequence().filter { !(it.isGroup) }.map { it.toRoomItem() }.toList()
+        groups = rooms.asSequence().filter { it.isGroup }.map { it.toRoomItem() }.toList()
 
         displayGroupsAndFriends()
 
@@ -86,8 +87,10 @@ class FriendsFragment : Fragment() {
             Log.d("FriendsFragment", item.toString())
 
             val roomId = (item as RoomItem).roomId
+            val roomServerId = item.roomServerId
             val intent = Intent(activity, TalkActivity::class.java)
             intent.putExtra(EXTRA_ROOM_ID, roomId)
+            intent.putExtra(EXTRA_ROOM_SERVER_ID, roomServerId)
 
             startActivity(intent)
         }

--- a/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/FriendsFragment.kt
@@ -53,8 +53,8 @@ class FriendsFragment : Fragment() {
         }
 
         val rooms = loadRooms()
-        friends = rooms.asSequence().filter { !(it.isGroup) }.map { it.toRoomItem() }.toList()
-        groups = rooms.asSequence().filter { it.isGroup }.map { it.toRoomItem() }.toList()
+        friends = rooms.asSequence().filter { !(it.isGroup) }.map { RoomItem(it) }.toList()
+        groups = rooms.asSequence().filter { it.isGroup }.map { RoomItem(it) }.toList()
 
         displayGroupsAndFriends()
 

--- a/android-client/app/src/main/java/com/sample/android_client/Room.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/Room.kt
@@ -1,7 +1,3 @@
 package com.sample.android_client
 
-class Room(val id: Int, val serverId: Int, val iconId: Int, val name: String, val isGroup: Boolean) {
-    fun toRoomItem(): RoomItem {
-        return RoomItem(id, serverId, name, iconId)
-    }
-}
+data class Room(val id: Int, val serverId: Int, val iconId: Int, val name: String, val isGroup: Boolean)

--- a/android-client/app/src/main/java/com/sample/android_client/Room.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/Room.kt
@@ -2,6 +2,6 @@ package com.sample.android_client
 
 class Room(val id: Int, val serverId: Int, val iconId: Int, val name: String, val isGroup: Boolean) {
     fun toRoomItem(): RoomItem {
-        return RoomItem(id, name, iconId)
+        return RoomItem(id, serverId, name, iconId)
     }
 }

--- a/android-client/app/src/main/java/com/sample/android_client/RoomItem.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/RoomItem.kt
@@ -7,6 +7,7 @@ import kotlinx.android.synthetic.main.item_friend_friends.*
 const val LIMIT_DISPLAY_NAME_LENGTH = 13
 
 data class RoomItem(val roomId: Int,
+                    val roomServerId: Int,
                     val roomName: String,
                     val roomIconId: Int) : Item() {
     override fun bind(viewHolder: ViewHolder, position: Int) {

--- a/android-client/app/src/main/java/com/sample/android_client/RoomItem.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/RoomItem.kt
@@ -6,10 +6,13 @@ import kotlinx.android.synthetic.main.item_friend_friends.*
 
 const val LIMIT_DISPLAY_NAME_LENGTH = 13
 
-data class RoomItem(val roomId: Int,
-                    val roomServerId: Int,
-                    val roomName: String,
-                    val roomIconId: Int) : Item() {
+class RoomItem(val roomId: Int,
+               val roomServerId: Int,
+               val roomName: String,
+               val roomIconId: Int) : Item() {
+
+    constructor(room: Room) : this(room.id, room.serverId, room.name, room.iconId)
+
     override fun bind(viewHolder: ViewHolder, position: Int) {
         viewHolder.user_name_textview_friends.text = if (roomName.length <= LIMIT_DISPLAY_NAME_LENGTH) {
             roomName
@@ -23,5 +26,4 @@ data class RoomItem(val roomId: Int,
     override fun getLayout(): Int = R.layout.item_friend_friends
 
     override fun getSpanSize(spanCount: Int, position: Int): Int = spanCount / 4
-
 }

--- a/android-client/app/src/main/java/com/sample/android_client/ServerAPI.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/ServerAPI.kt
@@ -18,9 +18,9 @@ interface ServerAPI {
 
 class MessageReceiver(val type: String,
                       val id: Int,
-                      val content: String,
                       val senderId: Int,
                       val roomId: Int,
+                      val content: String,
                       @SerializedName("SendTime") val sendTime: Timestamp) {
     fun toMessage(): Message {
         return Message(id, roomId, senderId, content, sendTime)

--- a/android-client/app/src/main/java/com/sample/android_client/ServerAPI.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/ServerAPI.kt
@@ -17,9 +17,9 @@ interface ServerAPI {
 
 class MessageReceiver(val type: String,
                       val id: Int,
-                      val roomId: Int,
-                      val senderId: Int,
                       val content: String,
+                      val senderId: Int,
+                      val roomId: Int,
                       @SerializedName("SendTime") val sendTime: Timestamp) {
     fun toMessage(): Message {
         return Message(id, roomId, senderId, content, sendTime)

--- a/android-client/app/src/main/java/com/sample/android_client/ServerAPI.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/ServerAPI.kt
@@ -3,14 +3,15 @@ package com.sample.android_client
 import com.google.gson.annotations.SerializedName
 import io.reactivex.Observable
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
 import java.sql.Timestamp
 
 interface ServerAPI {
-    @GET("message")
-    fun fetchAllMessages(): Observable<List<MessageReceiver>>
-  
+    @GET("messagestring")
+    fun fetchAllMessages(@Header("Token") token: String): Observable<List<MessageReceiver>>
+
     @POST("message/{userId}/{roomId}/{content}")
     fun postNewMessage(@Path("userId") userId: Int, @Path("roomId") roomId: Int, @Path("content") content: String): Observable<Boolean>
 }

--- a/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
@@ -22,7 +22,6 @@ import retrofit2.converter.gson.GsonConverterFactory
 import java.net.SocketTimeoutException
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
-import java.util.*
 import java.util.concurrent.TimeUnit
 
 class TalkActivity : RxActivity() {
@@ -58,12 +57,8 @@ class TalkActivity : RxActivity() {
             // TODO: message送信処理
 
             if (message.isNotEmpty()) {
-                FirebaseUtil().getIdToken()
+                serverAPI.postNewMessage(1, roomId, message)
                         .subscribeOn(Schedulers.io())
-                        .observeOn(Schedulers.io())
-                        .flatMap {
-                            serverAPI.postNewMessage(1, roomId, message)
-                        }
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribeBy(
                                 onNext = {
@@ -86,7 +81,7 @@ class TalkActivity : RxActivity() {
     override fun onResume() {
         super.onResume()
 
-        Log.d("TalkActivity","onResume")
+        Log.d("TalkActivity", "onResume")
         newMessages.clear()
 
         val pastMessages = loadPastMessages()
@@ -97,7 +92,7 @@ class TalkActivity : RxActivity() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .retryWhen {
                     it.flatMap {
-                        Log.d("TalkActivity","retry")
+                        Log.d("TalkActivity", "retry")
                         Toast.makeText(applicationContext, "Can't fetch new message...", Toast.LENGTH_SHORT).show()
                         Observable.timer(3, TimeUnit.SECONDS)
                                 .bindUntilEvent(this@TalkActivity, ActivityEvent.PAUSE)
@@ -109,7 +104,7 @@ class TalkActivity : RxActivity() {
                             newMessages.addAll(fetchedMessages)
                             talkAdapter.insertNewMessages(fetchedMessages)
 
-                            Log.d("TalkActivity","onNext")
+                            Log.d("TalkActivity", "onNext")
                             talk_recycler_view.scrollToPosition(talkAdapter.itemCount - 1)
                         }
                 )
@@ -118,7 +113,7 @@ class TalkActivity : RxActivity() {
     override fun onPause() {
         super.onPause()
 
-        Log.d("TalkActivity","onPause")
+        Log.d("TalkActivity", "onPause")
         saveNewMessages()?.subscribe()
     }
 

--- a/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
@@ -41,6 +41,7 @@ class TalkActivity : RxActivity() {
             .build()
             .create(ServerAPI::class.java)
 
+    private lateinit var token: String
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -53,6 +54,9 @@ class TalkActivity : RxActivity() {
             RuntimeException("ルームIdが取得できませんでした")
 
         }
+
+        FirebaseUtil().getIdToken().subscribe { token = it }
+        Log.d("TalkActivity", token)
 
         talk_recycler_view.adapter = talkAdapter
         talk_recycler_view.layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
@@ -147,7 +151,7 @@ class TalkActivity : RxActivity() {
         return Observable.interval(1, TimeUnit.SECONDS)
                 .bindUntilEvent(this, ActivityEvent.PAUSE)
                 .subscribeOn(Schedulers.io())
-                .flatMap { serverAPI.fetchAllMessages() }
+                .flatMap { serverAPI.fetchAllMessages(token) }
                 .map {
                     it.asSequence()
                             .filter { it.roomId == roomServerId }

--- a/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/TalkActivity.kt
@@ -30,6 +30,7 @@ class TalkActivity : RxActivity() {
 
     // TODO Activity起動時に代入するように変更する
     private var roomId = -1
+    private var roomServerId = -1
     private val newMessages = mutableListOf<Message>()
     private val talkAdapter = MessageRecyclerViewAdapter()
 
@@ -46,8 +47,11 @@ class TalkActivity : RxActivity() {
         setContentView(R.layout.activity_talk)
 
         roomId = intent.getIntExtra(EXTRA_ROOM_ID, -1)
-        if (roomId == -1) {
+        roomServerId = intent.getIntExtra(EXTRA_ROOM_SERVER_ID, -1)
+
+        if (roomId == -1 || roomServerId == -1) {
             RuntimeException("ルームIdが取得できませんでした")
+
         }
 
         talk_recycler_view.adapter = talkAdapter
@@ -57,7 +61,7 @@ class TalkActivity : RxActivity() {
             // TODO: message送信処理
 
             if (message.isNotEmpty()) {
-                serverAPI.postNewMessage(1, roomId, message)
+                serverAPI.postNewMessage(1, roomServerId, message)
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribeBy(
@@ -146,7 +150,7 @@ class TalkActivity : RxActivity() {
                 .flatMap { serverAPI.fetchAllMessages() }
                 .map {
                     it.asSequence()
-                            .filter { it.roomId == roomId }
+                            .filter { it.roomId == roomServerId }
                             .drop(talkAdapter.itemCount)
                             .map { it.toMessage() }
                 }


### PR DESCRIPTION
## 修正した点
1.  idが1以外のroomで更新が出来ない
1. ほかのルームのメッセージが表示される

## 変更内容
1. httpレスポンスとレシーバクラスのメンバが統一されていなかったので、レシーバクラスをhttpレスポンスに合わせた
1. 更新されたメッセージをローカル上のデータベースのidでフィルタしていたので、サーバー側のidでフィルタするようした
