### PR TITLE
初回ログイン(ユーザ登録)に成功したら次からは自動でログインする

### DIFF
--- a/android-client/app/src/main/java/com/sample/android_client/LoginActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/LoginActivity.kt
@@ -1,6 +1,7 @@
 package com.sample.android_client
 
 import android.content.Intent
+import android.content.SharedPreferences
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
@@ -9,10 +10,13 @@ import com.google.firebase.auth.FirebaseAuth
 import kotlinx.android.synthetic.main.activity_login.*
 
 class LoginActivity : AppCompatActivity() {
+    lateinit var prefs: SharedPreferences
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
+
+        prefs = getSharedPreferences(getString(R.string.preference_key), AppCompatActivity.MODE_PRIVATE)
 
         login_button_login.setOnClickListener {
             performLogin()
@@ -43,6 +47,17 @@ class LoginActivity : AppCompatActivity() {
                     // ログインに成功した場合
                     Log.d("LoginActivity", "Successfully login with email/password: $email/****")
                     Toast.makeText(this, "ログインしました！", Toast.LENGTH_SHORT).show()
+
+                    val editer = prefs.edit()
+                    editer.putString("email", email)
+                    editer.putString("password", password)
+                    editer.commit()
+
+                    val email_local = prefs.getString("email", "null")
+                    val password_local = prefs.getString("password", "null")
+
+                    Log.d("LoginActivity", "Email:$email_local")
+                    Log.d("LoginActivity", "Password:$password_local")
 
                     val intent = Intent(this, HomeActivity::class.java)
                     startActivity(intent)

--- a/android-client/app/src/main/java/com/sample/android_client/LoginActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/LoginActivity.kt
@@ -2,8 +2,8 @@ package com.sample.android_client
 
 import android.content.Intent
 import android.content.SharedPreferences
-import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
 import android.util.Log
 import android.widget.Toast
 import com.google.firebase.auth.FirebaseAuth
@@ -17,6 +17,20 @@ class LoginActivity : AppCompatActivity() {
         setContentView(R.layout.activity_login)
 
         prefs = getSharedPreferences(getString(R.string.preference_key), AppCompatActivity.MODE_PRIVATE)
+        val email = prefs.getString("email", "hoge")
+        val password = prefs.getString("password", "fuga")
+
+        if (email != "hoge" && password != "fuga") {
+            FirebaseAuth.getInstance()
+                    .signInWithEmailAndPassword(email, password)
+                    .addOnSuccessListener {
+                        val intent = Intent(this, HomeActivity::class.java)
+                        startActivity(intent)
+                    }
+                    .addOnFailureListener {
+                        RuntimeException("Can't log in.")
+                    }
+        }
 
         login_button_login.setOnClickListener {
             performLogin()

--- a/android-client/app/src/main/java/com/sample/android_client/LoginActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/LoginActivity.kt
@@ -44,17 +44,6 @@ class LoginActivity : AppCompatActivity() {
                     Log.d("LoginActivity", "Successfully login with email/password: $email/****")
                     Toast.makeText(this, "ログインしました！", Toast.LENGTH_SHORT).show()
 
-                    // idTokenの取得
-                    var idToken: String? = null
-
-                    FirebaseAuth.getInstance()
-                            .currentUser
-                            ?.getIdToken(true)
-                            ?.addOnSuccessListener {
-                                idToken = it.token
-                                Log.d("LoginActivity", "idToken:" + idToken)
-                            }
-
                     val intent = Intent(this, HomeActivity::class.java)
                     startActivity(intent)
                 }

--- a/android-client/app/src/main/java/com/sample/android_client/LoginActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/LoginActivity.kt
@@ -14,8 +14,7 @@ class LoginActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_login)
-
+        
         prefs = getSharedPreferences(getString(R.string.preference_key), AppCompatActivity.MODE_PRIVATE)
         val email = prefs.getString("email", "hoge")
         val password = prefs.getString("password", "fuga")
@@ -30,15 +29,17 @@ class LoginActivity : AppCompatActivity() {
                     .addOnFailureListener {
                         RuntimeException("Can't log in.")
                     }
-        }
+        } else {
+            setContentView(R.layout.activity_login)
 
-        login_button_login.setOnClickListener {
-            performLogin()
-        }
+            login_button_login.setOnClickListener {
+                performLogin()
+            }
 
-        go_to_registration_textview.setOnClickListener {
-            val intent = Intent(this, RegistrationActivity::class.java)
-            startActivity(intent)
+            go_to_registration_textview.setOnClickListener {
+                val intent = Intent(this, RegistrationActivity::class.java)
+                startActivity(intent)
+            }
         }
     }
 

--- a/android-client/app/src/main/java/com/sample/android_client/LoginActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/LoginActivity.kt
@@ -14,12 +14,12 @@ class LoginActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        
-        prefs = getSharedPreferences(getString(R.string.preference_key), AppCompatActivity.MODE_PRIVATE)
-        val email = prefs.getString("email", "hoge")
-        val password = prefs.getString("password", "fuga")
 
-        if (email != "hoge" && password != "fuga") {
+        prefs = getSharedPreferences(getString(R.string.preference_key), AppCompatActivity.MODE_PRIVATE)
+        val email = prefs.getString("email", "null")
+        val password = prefs.getString("password", "null")
+
+        if (email != "null" && password != "null") {
             FirebaseAuth.getInstance()
                     .signInWithEmailAndPassword(email, password)
                     .addOnSuccessListener {

--- a/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
+++ b/android-client/app/src/main/java/com/sample/android_client/RegistrationActivity.kt
@@ -2,6 +2,7 @@ package com.sample.android_client
 
 import android.app.Activity
 import android.content.Intent
+import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
@@ -17,12 +18,15 @@ import java.util.*
 const val LIMIT_USER_NAME_LENGTH = 20        // ユーザが登録できる名前の長さの限界
 
 class RegistrationActivity : AppCompatActivity() {
+    lateinit var prefs: SharedPreferences
     var selectedPhotoUri: Uri? = null   // アイコンにするために選択した画像のURI
     var userUID: String? = null         // Firebaseで発行されるUID
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_registration)
+
+        prefs = getSharedPreferences(getString(com.sample.android_client.R.string.preference_key), AppCompatActivity.MODE_PRIVATE)
 
         register_button_register.setOnClickListener {
             performRegister()
@@ -78,6 +82,11 @@ class RegistrationActivity : AppCompatActivity() {
                         Log.d("RegistrationActivity", "アイコンが選択されていないのでデフォルトアイコンを設定する")
                         // TODO: デフォルトアイコンを設定する
                     }
+
+                    val editor = prefs.edit()
+                    editor.putString("email", email)
+                    editor.putString("password", password)
+                    editor.commit()
 
                     // 登録したユーザアイコンをFirebaseのストレージに保存する
                     // 実際はFirebaseではなく、しかるべき場所(EC2?)に保存するなどする

--- a/android-client/app/src/main/res/values/strings.xml
+++ b/android-client/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">android-client</string>
+    <string name="preference_key">cache_cache_email_and_password</string>
     <string name="title_friends">友だち</string>
     <string name="title_latest_messages">最新メッセージ</string>
     <string name="title_settings">設定</string>


### PR DESCRIPTION
# 概要
初回ログイン(ユーザ登録)に成功したら次からは自動でログインするようにしました。
SharedPreferencesにemail, passwordを平文で保存しています。
セキュリティ的にはpasswordは暗号化して保存したほうがよいみたいですが……余裕が出来たら対応します。

# 参考
https://techracho.bpsinc.jp/baba/2011_07_23/3526
https://techracho.bpsinc.jp/baba/2012_09_23/4009